### PR TITLE
Update dependencies, bump MSRV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
 
 language: rust
 rust:
-  - 1.35.0
+  - 1.39.0
 cache:
   - cargo
 
@@ -40,29 +40,29 @@ jobs:
         - rustup component add clippy
         - cargo clippy -V
       script:
-        - cargo fmt -- --check
+        - cargo fmt --all -- --check
         - cargo clippy --features secp256k1 --lib --tests -- -D warnings
         - cargo clippy --no-default-features --features ed25519-dalek --lib --tests -- -D warnings
         - cargo test --features secp256k1 --lib --tests
         - cargo test --no-default-features --features ed25519-dalek --lib --tests
         - cargo test --doc
-        - cargo clean --doc && cargo doc --features secp256k1 --no-deps && cargo deadlinks --dir target/doc
+        - cargo clean --doc && cargo doc --features secp256k1 --no-deps && cargo deadlinks --check-http
 
     - stage: deploy
-      rust: nightly-2019-06-16
+      rust: nightly-2020-01-05
       script:
         - |
           cargo clean --doc && \
           cargo rustdoc --features secp256k1 -- -Z unstable-options \
-            --extern-html-root-url base64=https://docs.rs/base64/0.10.1 \
-            --extern-html-root-url exonum-crypto=https://docs.rs/exonum-crypto/0.11.0 \
-            --extern-html-root-url failure=https://docs.rs/failure/0.1.5 \
-            --extern-html-root-url digest=https://docs.rs/digest/0.8.0 \
-            --extern-html-root-url hmac=https://docs.rs/hmac/0.7.0 \
-            --extern-html-root-url crypto-mac=https://docs.rs/crypto-mac/0.7.0 \
-            --extern-html-root-url secp256k1=https://docs.rs/secp256k1/0.12.0 \
-            --extern-html-root-url serde_json=https://docs.rs/serde_json/1.0.39 \
-            --extern-html-root-url serde_cbor=https://docs.rs/serde_cbor/0.9.0
+            --extern-html-root-url base64=https://docs.rs/base64/~0.12 \
+            --extern-html-root-url exonum-crypto=https://docs.rs/exonum-crypto/~0.12 \
+            --extern-html-root-url failure=https://docs.rs/failure/~0.1 \
+            --extern-html-root-url digest=https://docs.rs/digest/~0.8 \
+            --extern-html-root-url hmac=https://docs.rs/hmac/~0.7 \
+            --extern-html-root-url crypto-mac=https://docs.rs/crypto-mac/~0.7 \
+            --extern-html-root-url secp256k1=https://docs.rs/secp256k1/~0.17 \
+            --extern-html-root-url serde_json=https://docs.rs/serde_json/~1 \
+            --extern-html-root-url serde_cbor=https://docs.rs/serde_cbor/~0.11
       deploy:
         provider: pages
         local-dir: target/doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,32 +15,28 @@ repository = "https://github.com/slowli/jwt-compact"
 features = ["secp256k1"]
 
 [dependencies]
-base64 = "0.10.1"
-chrono = "0.4.7"
-clear_on_drop = "0.2.3"
-failure = "0.1.5"
-failure_derive = "0.1.5"
-rand_core = "0.5.0"
-serde = "1.0"
-serde_cbor = "0.9.0"
-serde_derive = "1.0"
+base64 = "0.12.0"
+chrono = "0.4.11"
+failure = "0.1.7"
+rand_core = "0.5.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_cbor = "0.11.1"
 serde_json = "1.0"
-smallvec = "0.6.10"
+smallvec = "1.2"
+zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
 # Crypto backends
-hmac = "0.7.0"
-sha2 = "0.8.0"
+hmac = "0.7.1"
+sha2 = "0.8.1"
 exonum-crypto = { version = "0.12.0", optional = true }
-ed25519-dalek = { version = "1.0.0-pre.1", optional = true }
-secp256k1 = { version = "0.15.0", optional = true }
+ed25519-dalek = { version = "1.0.0-pre.3", optional = true }
+secp256k1 = { version = "0.17.2", optional = true }
 
 [dev-dependencies]
-assert_matches = "1.3.0"
-hex = "0.3.2"
+assert_matches = "1.3"
+hex = "0.4.2"
 hex-buffer-serde = "0.2.0"
-rand = "0.7.0"
-# Required to generate keys for `ed25519-dalek`.
-rand6 = { package = "rand", version = "0.6.5" }
+rand = "0.7.3"
 
 [features]
 default = ["exonum-crypto"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis Build Status](https://img.shields.io/travis/com/slowli/jwt-compact/master.svg?label=Linux%20Build)](https://travis-ci.com/slowli/jwt-compact) 
 [![License: Apache-2.0](https://img.shields.io/github/license/slowli/jwt-compact.svg)](https://github.com/slowli/jwt-compact/blob/master/LICENSE)
-![rust 1.35.0+ required](https://img.shields.io/badge/rust-1.35.0+-blue.svg?label=Required%20Rust)
+![rust 1.39.0+ required](https://img.shields.io/badge/rust-1.39.0+-blue.svg?label=Required%20Rust)
 
 **Documentation:** [![crate docs (master)](https://img.shields.io/badge/master-yellow.svg?label=docs)](https://slowli.github.io/jwt-compact/jwt_compact/) 
 

--- a/src/alg/hmacs.rs
+++ b/src/alg/hmacs.rs
@@ -1,4 +1,3 @@
-use clear_on_drop::clear::Clear;
 use failure::bail;
 use hmac::crypto_mac::generic_array::{
     typenum::{Unsigned, U32, U48, U64},
@@ -8,6 +7,7 @@ use hmac::{crypto_mac::MacResult, Hmac, Mac as _};
 use rand_core::{CryptoRng, RngCore};
 use sha2::{digest::BlockInput, Sha256, Sha384, Sha512};
 use smallvec::{smallvec, SmallVec};
+use zeroize::Zeroize;
 
 use std::{borrow::Cow, fmt};
 
@@ -19,18 +19,13 @@ macro_rules! define_hmac_key {
         struct $name:ident<$digest:ident, $out_size:ident>([u8; $buffer_size:expr]);
     ) => {
         $(#[$($attr)+])*
-        #[derive(Clone)]
+        #[derive(Clone, Zeroize)]
+        #[zeroize(drop)]
         pub struct $name(pub(crate) SmallVec<[u8; $buffer_size]>);
 
         impl fmt::Debug for $name {
             fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.debug_tuple(stringify!($name)).field(&"_").finish()
-            }
-        }
-
-        impl Drop for $name {
-            fn drop(&mut self) {
-                Clear::clear(&mut self.0);
             }
         }
 

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Duration, Utc};
-use serde_derive::*;
+use serde::{Deserialize, Serialize};
 
 use crate::ValidationError;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use failure_derive::*;
+use failure::*;
 
 /// Errors that may occur during token parsing.
 #[derive(Debug, Fail)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //! # use failure::Error;
 //! use chrono::{Duration, Utc};
 //! use jwt_compact::{prelude::*, alg::{Hs256, Hs256Key}};
-//! use serde_derive::*;
+//! use serde::{Serialize, Deserialize};
 //! use std::convert::TryFrom;
 //!
 //! /// Custom claims encoded in the token.
@@ -115,7 +115,7 @@
 //! # use failure::Error;
 //! # use hex_buffer_serde::{Hex as _, HexForm};
 //! # use jwt_compact::{prelude::*, alg::{Hs256, Hs256Key}};
-//! # use serde_derive::*;
+//! # use serde::{Serialize, Deserialize};
 //! # use std::convert::TryFrom;
 //! /// Custom claims encoded in the token.
 //! #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -150,8 +150,7 @@
 
 #![deny(missing_debug_implementations, missing_docs, bare_trait_objects)]
 
-use serde::{de::DeserializeOwned, Serialize};
-use serde_derive::*;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 
 use std::{borrow::Cow, convert::TryFrom};

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -3,7 +3,7 @@ use chrono::{Duration, Utc};
 use hex_buffer_serde::{Hex as _, HexForm};
 use jwt_compact::{alg::*, prelude::*, Algorithm, ValidationError};
 use rand::thread_rng;
-use serde_derive::*;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use std::{collections::HashMap, convert::TryFrom};
@@ -231,7 +231,7 @@ fn test_algorithm<A: Algorithm>(
     // Mutate claims.
     let claims_string = base64::encode_config(
         &serde_json::to_vec(&{
-            let mut mangled_claims = claims.clone();
+            let mut mangled_claims = claims;
             let issued_at = mangled_claims.issued_at.as_mut().unwrap();
             *issued_at = *issued_at + Duration::seconds(1);
             mangled_claims
@@ -330,7 +330,10 @@ fn ed25519_algorithm() {
 #[test]
 fn ed25519_algorithm() {
     use ed25519_dalek::Keypair;
-    let keypair = Keypair::generate(&mut rand6::thread_rng());
+    use rand::rngs::OsRng;
+
+    let mut csprng = OsRng {};
+    let keypair = Keypair::generate(&mut csprng);
     test_algorithm(&Ed25519, &keypair, &keypair.public);
 }
 


### PR DESCRIPTION
IMO, `zeroize` has a much simpler approach to clearing memory and it's more portable. Also, it looks like the `clear_on_drop` crate isn't actively maintained.