### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Changed
+
+- Update dependencies.
+
 ## 0.2.0 - 2020-05-11
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ serde_cbor = "0.11.1"
 serde_json = "1.0"
 
 # Crypto backends (all public dependencies).
-hmac = "0.7.1"
-sha2 = "0.8.1"
+hmac = "0.8.0"
+sha2 = "0.9.0"
 ed25519-dalek = { version = "1.0.0-pre.3", optional = true }
 secp256k1 = { version = "0.17.2", optional = true }
 

--- a/src/alg/es256k.rs
+++ b/src/alg/es256k.rs
@@ -73,8 +73,8 @@ where
 
     fn sign(&self, signing_key: &Self::SigningKey, message: &[u8]) -> Self::Signature {
         let mut digest = D::default();
-        digest.input(message);
-        let message = Message::from_slice(&digest.result())
+        digest.update(message);
+        let message = Message::from_slice(&digest.finalize())
             .expect("failed to convert message to the correct form");
 
         self.context.sign(&message, signing_key)
@@ -87,8 +87,8 @@ where
         message: &[u8],
     ) -> bool {
         let mut digest = D::default();
-        digest.input(message);
-        let message = Message::from_slice(&digest.result())
+        digest.update(message);
+        let message = Message::from_slice(&digest.finalize())
             .expect("failed to convert message to the correct form");
 
         self.context


### PR DESCRIPTION
Updates `hmac` and `sha2` dependencies.

Supersedes #6, #7.