### PR TITLE
Add support for the ed25519-compact backend

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,6 +56,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --no-default-features --features ed25519-dalek --all-targets
+      - name: Clippy ed25519-compact
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --no-default-features --features ed25519-compact --all-targets
 
       - name: Run tests
         uses: actions-rs/cargo@v1
@@ -67,6 +72,11 @@ jobs:
         with:
           command: test
           args: --no-default-features --features ed25519-dalek --lib --tests
+      - name: Test ed25519-compact
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features ed25519-compact --lib --tests
 
       - name: Check docs
         run: cargo clean --doc && cargo doc --features secp256k1 --no-deps && cargo deadlinks --dir target/doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ default-features = false
 features = ["sodiumoxide-crypto"]
 optional = true
 
+[dependencies.ed25519-compact]
+version = "0.1.4"
+optional = true
+
 [dev-dependencies]
 assert_matches = "1.3"
 hex = "0.4.2"

--- a/src/alg.rs
+++ b/src/alg.rs
@@ -4,11 +4,15 @@
 mod es256k;
 mod hmacs;
 // Alternative EdDSA implementations.
+#[cfg(feature = "ed25519-compact")]
+mod eddsa_compact;
 #[cfg(feature = "ed25519-dalek")]
 mod eddsa_dalek;
 #[cfg(feature = "exonum-crypto")]
 mod eddsa_sodium;
 
+#[cfg(feature = "ed25519-compact")]
+pub use self::eddsa_compact::Ed25519;
 #[cfg(feature = "ed25519-dalek")]
 pub use self::eddsa_dalek::Ed25519;
 #[cfg(feature = "exonum-crypto")]

--- a/src/alg.rs
+++ b/src/alg.rs
@@ -12,7 +12,7 @@ mod eddsa_dalek;
 mod eddsa_sodium;
 
 #[cfg(feature = "ed25519-compact")]
-pub use self::eddsa_compact::Ed25519;
+pub use self::eddsa_compact::*;
 #[cfg(feature = "ed25519-dalek")]
 pub use self::eddsa_dalek::Ed25519;
 #[cfg(feature = "exonum-crypto")]

--- a/src/alg/eddsa_compact.rs
+++ b/src/alg/eddsa_compact.rs
@@ -1,6 +1,9 @@
-use ed25519_compact::{PublicKey, SecretKey, Signature};
+use ed25519_compact::{KeyPair, PublicKey, SecretKey, Seed, Signature};
+use rand::Rng;
+use rand_core::{CryptoRng, RngCore};
 
 use std::borrow::Cow;
+use std::fmt;
 
 use crate::{Algorithm, AlgorithmSignature, Renamed};
 
@@ -16,6 +19,50 @@ impl AlgorithmSignature for Signature {
 
     fn as_bytes(&self) -> Cow<[u8]> {
         Cow::Owned(self.as_ref().to_vec())
+    }
+}
+
+/// A verification key.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Ed25519VerifyingKey(PublicKey);
+
+impl AsRef<PublicKey> for Ed25519VerifyingKey {
+    fn as_ref(&self) -> &PublicKey {
+        &self.0
+    }
+}
+
+impl Ed25519VerifyingKey {
+    /// Create a verification key from a slice.
+    pub fn from_slice(raw: &[u8]) -> anyhow::Result<Ed25519VerifyingKey> {
+        Ok(Ed25519VerifyingKey(PublicKey::from_slice(raw)?))
+    }
+}
+
+/// A signing key.
+pub struct Ed25519SigningKey(SecretKey);
+
+impl fmt::Debug for Ed25519SigningKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Ed25519 secret key: {:?}", self.as_ref().as_ref())
+    }
+}
+
+impl AsRef<SecretKey> for Ed25519SigningKey {
+    fn as_ref(&self) -> &SecretKey {
+        &self.0
+    }
+}
+
+impl Ed25519SigningKey {
+    /// Create a signing key from a slice.
+    pub fn from_slice(raw: &[u8]) -> anyhow::Result<Ed25519SigningKey> {
+        Ok(Ed25519SigningKey(SecretKey::from_slice(raw)?))
+    }
+
+    /// Convert a signing key to a verification key.
+    pub fn to_verifying_key(&self) -> PublicKey {
+        self.as_ref().public_key()
     }
 }
 
@@ -36,11 +83,23 @@ impl Ed25519 {
     pub fn with_specific_name() -> Renamed<Self> {
         Renamed::new(Self, "Ed25519")
     }
+
+    /// Generate a new key pair.
+    pub fn generate<R: CryptoRng + RngCore>(
+        &self,
+        rng: &mut R,
+    ) -> (Ed25519SigningKey, Ed25519VerifyingKey) {
+        let keypair = KeyPair::from_seed(Seed::new(rng.gen()));
+        (
+            Ed25519SigningKey(keypair.sk),
+            Ed25519VerifyingKey(keypair.pk),
+        )
+    }
 }
 
 impl Algorithm for Ed25519 {
-    type SigningKey = SecretKey;
-    type VerifyingKey = PublicKey;
+    type SigningKey = Ed25519SigningKey;
+    type VerifyingKey = Ed25519VerifyingKey;
     type Signature = Signature;
 
     fn name(&self) -> Cow<'static, str> {
@@ -48,7 +107,7 @@ impl Algorithm for Ed25519 {
     }
 
     fn sign(&self, signing_key: &Self::SigningKey, message: &[u8]) -> Self::Signature {
-        signing_key.sign(message, Some(Default::default()))
+        signing_key.as_ref().sign(message, Some(Default::default()))
     }
 
     fn verify_signature(
@@ -57,6 +116,6 @@ impl Algorithm for Ed25519 {
         verifying_key: &Self::VerifyingKey,
         message: &[u8],
     ) -> bool {
-        verifying_key.verify(message, signature).is_ok()
+        verifying_key.as_ref().verify(message, signature).is_ok()
     }
 }

--- a/src/alg/eddsa_compact.rs
+++ b/src/alg/eddsa_compact.rs
@@ -37,6 +37,11 @@ impl Ed25519VerifyingKey {
     pub fn from_slice(raw: &[u8]) -> anyhow::Result<Ed25519VerifyingKey> {
         Ok(Ed25519VerifyingKey(PublicKey::from_slice(raw)?))
     }
+
+    /// Return the key as raw bytes.
+    pub fn as_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.as_ref().as_ref().to_vec())
+    }
 }
 
 /// A signing key.
@@ -63,6 +68,11 @@ impl Ed25519SigningKey {
     /// Convert a signing key to a verification key.
     pub fn to_verifying_key(&self) -> PublicKey {
         self.as_ref().public_key()
+    }
+
+    /// Return the key as raw bytes.
+    pub fn as_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.as_ref().as_ref().to_vec())
     }
 }
 

--- a/src/alg/eddsa_compact.rs
+++ b/src/alg/eddsa_compact.rs
@@ -1,9 +1,7 @@
 use ed25519_compact::{KeyPair, PublicKey, SecretKey, Seed, Signature};
-use rand::Rng;
 use rand_core::{CryptoRng, RngCore};
 
-use std::borrow::Cow;
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 use crate::{Algorithm, AlgorithmSignature, Renamed};
 
@@ -40,7 +38,7 @@ impl Ed25519VerifyingKey {
 
     /// Return the key as raw bytes.
     pub fn as_bytes(&self) -> Cow<[u8]> {
-        Cow::Owned(self.as_ref().as_ref().to_vec())
+        Cow::Borrowed(self.as_ref().as_ref())
     }
 }
 
@@ -48,7 +46,7 @@ impl Ed25519VerifyingKey {
 pub struct Ed25519SigningKey(SecretKey);
 
 impl fmt::Debug for Ed25519SigningKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Ed25519 secret key: {:?}", self.as_ref().as_ref())
     }
 }
@@ -99,7 +97,9 @@ impl Ed25519 {
         &self,
         rng: &mut R,
     ) -> (Ed25519SigningKey, Ed25519VerifyingKey) {
-        let keypair = KeyPair::from_seed(Seed::new(rng.gen()));
+        let mut seed = [0u8; Seed::BYTES];
+        rng.fill_bytes(&mut seed);
+        let keypair = KeyPair::from_seed(Seed::new(seed));
         (
             Ed25519SigningKey(keypair.sk),
             Ed25519VerifyingKey(keypair.pk),

--- a/src/alg/eddsa_compact.rs
+++ b/src/alg/eddsa_compact.rs
@@ -1,0 +1,62 @@
+use ed25519_compact::{PublicKey, SecretKey, Signature};
+
+use std::borrow::Cow;
+
+use crate::{Algorithm, AlgorithmSignature, Renamed};
+
+impl AlgorithmSignature for Signature {
+    fn try_from_slice(bytes: &[u8]) -> anyhow::Result<Self> {
+        let mut signature = [0u8; Signature::BYTES];
+        if bytes.len() != signature.len() {
+            return Err(ed25519_compact::Error::SignatureMismatch.into());
+        }
+        signature.copy_from_slice(bytes);
+        Ok(Self::new(signature))
+    }
+
+    fn as_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.as_ref().to_vec())
+    }
+}
+
+/// Integrity algorithm using digital signatures on the Ed25519 elliptic curve.
+///
+/// The name of the algorithm is specified as `EdDSA` as per the [IANA registry].
+/// Use `with_specific_name()` to switch to non-standard `Ed25519`.
+///
+/// *This type is available if the crate is built with the `ed25519-dalek` feature.*
+///
+/// [IANA registry]: https://www.iana.org/assignments/jose/jose.xhtml
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Ed25519;
+
+impl Ed25519 {
+    /// Creates an algorithm instance with the algorithm name specified as `Ed25519`.
+    /// This is a non-standard name, but it is used in some apps.
+    pub fn with_specific_name() -> Renamed<Self> {
+        Renamed::new(Self, "Ed25519")
+    }
+}
+
+impl Algorithm for Ed25519 {
+    type SigningKey = SecretKey;
+    type VerifyingKey = PublicKey;
+    type Signature = Signature;
+
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("EdDSA")
+    }
+
+    fn sign(&self, signing_key: &Self::SigningKey, message: &[u8]) -> Self::Signature {
+        signing_key.sign(message, Some(Default::default()))
+    }
+
+    fn verify_signature(
+        &self,
+        signature: &Self::Signature,
+        verifying_key: &Self::VerifyingKey,
+        message: &[u8],
+    ) -> bool {
+        verifying_key.verify(message, signature).is_ok()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 //! | `HS256`, `HS384`, `HS512` | - | Uses pure Rust [`sha2`] crate |
 //! | `EdDSA` (Ed25519) | [`exonum-crypto`] | [`libsodium`] binding. Enabled by default |
 //! | `EdDSA` (Ed25519) | [`ed25519-dalek`] | Pure Rust implementation |
+//! | `EdDSA` (Ed25519) | [`ed25519-compact`] | Compact pure Rust implementation, WASM-compatible |
 //! | `ES256K` | [`secp256k1`] | Binding for [`libsecp256k1`] |
 //!
 //! Standard `RS*`, `PS*` and `ES*` algorithms are not (yet?) implemented. The reasons (besides
@@ -50,6 +51,7 @@
 //! [`libsodium`]: https://download.libsodium.org/doc/
 //! [`exonum-crypto`]: https://docs.rs/exonum-crypto/
 //! [`ed25519-dalek`]: https://doc.dalek.rs/ed25519_dalek/
+//! [`ed25519-compact`]: https://crates.io/crates/ed25519-compact
 //! [`secp256k1`]: https://docs.rs/secp256k1/
 //! [`libsecp256k1`]: https://github.com/bitcoin-core/secp256k1
 //! [`Header`]: struct.Header.html

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -139,7 +139,11 @@ fn es256k_reference() {
     assert_eq!(token.claims().custom, *expected_claims.as_object().unwrap());
 }
 
-#[cfg(any(feature = "exonum-crypto", feature = "ed25519-dalek"))]
+#[cfg(any(
+    feature = "exonum-crypto",
+    feature = "ed25519-dalek",
+    feature = "ed25519-compact"
+))]
 #[test]
 fn ed25519_reference() {
     //! Generated using https://github.com/uport-project/did-jwt based on the unit tests
@@ -156,6 +160,9 @@ fn ed25519_reference() {
     let bytes_to_pk = exonum_crypto::PublicKey::from_slice;
     #[cfg(feature = "ed25519-dalek")]
     let bytes_to_pk = ed25519_dalek::PublicKey::from_bytes;
+    #[cfg(feature = "ed25519-compact")]
+    let bytes_to_pk = ed25519_compact::PublicKey::from_slice;
+
     let public_key = bytes_to_pk(&hex::decode(KEY).unwrap()).unwrap();
     let token = UntrustedToken::try_from(TOKEN).unwrap();
     assert_eq!(token.algorithm(), "Ed25519");
@@ -335,6 +342,16 @@ fn ed25519_algorithm() {
     let mut csprng = OsRng {};
     let keypair = Keypair::generate(&mut csprng);
     test_algorithm(&Ed25519, &keypair, &keypair.public);
+}
+
+#[cfg(feature = "ed25519-compact")]
+#[test]
+fn ed25519_algorithm() {
+    use ed25519_compact::{KeyPair, Seed};
+    use rand::Rng;
+
+    let keypair = KeyPair::from_seed(Seed::new(thread_rng().gen()));
+    test_algorithm(&Ed25519, &keypair.sk, &keypair.pk);
 }
 
 #[cfg(feature = "secp256k1")]

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -161,7 +161,7 @@ fn ed25519_reference() {
     #[cfg(feature = "ed25519-dalek")]
     let bytes_to_pk = ed25519_dalek::PublicKey::from_bytes;
     #[cfg(feature = "ed25519-compact")]
-    let bytes_to_pk = ed25519_compact::PublicKey::from_slice;
+    let bytes_to_pk = Ed25519VerifyingKey::from_slice;
 
     let public_key = bytes_to_pk(&hex::decode(KEY).unwrap()).unwrap();
     let token = UntrustedToken::try_from(TOKEN).unwrap();
@@ -347,11 +347,9 @@ fn ed25519_algorithm() {
 #[cfg(feature = "ed25519-compact")]
 #[test]
 fn ed25519_algorithm() {
-    use ed25519_compact::{KeyPair, Seed};
-    use rand::Rng;
-
-    let keypair = KeyPair::from_seed(Seed::new(thread_rng().gen()));
-    test_algorithm(&Ed25519, &keypair.sk, &keypair.pk);
+    let mut rng = thread_rng();
+    let (signing_key, verifying_key) = Ed25519.generate(&mut rng);
+    test_algorithm(&Ed25519, &signing_key, &verifying_key);
 }
 
 #[cfg(feature = "secp256k1")]


### PR DESCRIPTION
This introduces a new backend, `ed25519-compact`.

`ed25519-compact`

- is the smallest option
- doesn't bring  additional dependencies
- is written in pure rust
- supports WebAssembly

The last point is a major motivation for this addition, as the `jwt-compact` crate could be very useful for service workers leveraging WebAssembly.