### PR TITLE
Add optional support for RSA

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,11 +77,6 @@ jobs:
         with:
           command: test
           args: --no-default-features --features ed25519-compact --lib --tests
-      - name: Test RSA
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features rsa --lib --tests
 
       - name: Check docs
         run: cargo clean --doc && cargo doc --features es256k,rsa --no-deps && cargo deadlinks --dir target/doc
@@ -119,15 +114,16 @@ jobs:
         run: |
           cargo clean --doc && \
           cargo rustdoc --features es256k,rsa -- -Z unstable-options \
-            --extern-html-root-url base64=https://docs.rs/base64/~0.12 \
-            --extern-html-root-url exonum-crypto=https://docs.rs/exonum-crypto/1.0.0-rc.2 \
+            --extern-html-root-url base64=https://docs.rs/base64/~0.13 \
+            --extern-html-root-url exonum-crypto=https://docs.rs/exonum-crypto/1.0.0 \
             --extern-html-root-url anyhow=https://docs.rs/anyhow/~1.0 \
-            --extern-html-root-url digest=https://docs.rs/digest/~0.8 \
-            --extern-html-root-url hmac=https://docs.rs/hmac/~0.7 \
-            --extern-html-root-url crypto-mac=https://docs.rs/crypto-mac/~0.7 \
-            --extern-html-root-url secp256k1=https://docs.rs/secp256k1/~0.17 \
+            --extern-html-root-url digest=https://docs.rs/digest/~0.9 \
+            --extern-html-root-url hmac=https://docs.rs/hmac/~0.10 \
+            --extern-html-root-url crypto-mac=https://docs.rs/crypto-mac/~0.10 \
+            --extern-html-root-url secp256k1=https://docs.rs/secp256k1/~0.19 \
             --extern-html-root-url serde_json=https://docs.rs/serde_json/~1 \
             --extern-html-root-url serde_cbor=https://docs.rs/serde_cbor/~0.11
+            --extern-html-root-url rsa=https://docs.rs/rsa/~0.3
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,6 +61,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --no-default-features --features ed25519-compact --all-targets
+      - name: Clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --features secp256k1 rsa --all-targets
 
       - name: Run tests
         uses: actions-rs/cargo@v1
@@ -77,6 +82,11 @@ jobs:
         with:
           command: test
           args: --no-default-features --features ed25519-compact --lib --tests
+      - name: Test RSA
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features rsa --lib --tests
 
       - name: Check docs
         run: cargo clean --doc && cargo doc --features es256k --no-deps && cargo deadlinks --dir target/doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --features es256k --all-targets
+          args: --features es256k,rsa --all-targets
       - name: Clippy dalek crypto
         uses: actions-rs/clippy-check@v1
         with:
@@ -61,17 +61,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --no-default-features --features ed25519-compact --all-targets
-      - name: Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --features secp256k1 rsa --all-targets
 
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features es256k
+          args: --features es256k,rsa
       - name: Test dalek crypto
         uses: actions-rs/cargo@v1
         with:
@@ -89,7 +84,7 @@ jobs:
           args: --features rsa --lib --tests
 
       - name: Check docs
-        run: cargo clean --doc && cargo doc --features es256k --no-deps && cargo deadlinks --dir target/doc
+        run: cargo clean --doc && cargo doc --features es256k,rsa --no-deps && cargo deadlinks --dir target/doc
 
   document:
     needs: build
@@ -123,7 +118,7 @@ jobs:
       - name: Build docs
         run: |
           cargo clean --doc && \
-          cargo rustdoc --features es256k -- -Z unstable-options \
+          cargo rustdoc --features es256k,rsa -- -Z unstable-options \
             --extern-html-root-url base64=https://docs.rs/base64/~0.12 \
             --extern-html-root-url exonum-crypto=https://docs.rs/exonum-crypto/1.0.0-rc.2 \
             --extern-html-root-url anyhow=https://docs.rs/anyhow/~1.0 \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,10 @@ optional = true
 version = "0.1.4"
 optional = true
 
+[dependencies.rsa]
+version = "0.3"
+optional = true
+
 [dev-dependencies]
 assert_matches = "1.3"
 hex = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["web-programming", "cryptography"]
 description = "Minimalistic JWT implementation with focus on type safety and secure cryptographic primitives"
 repository = "https://github.com/slowli/jwt-compact"
 
-# Enable `ES256K` algorithm in documentation on `docs.rs`.
+# Enable non-conflicting additional algorithms in documentation on `docs.rs`.
 [package.metadata.docs.rs]
-features = ["es256k"]
+features = ["es256k", "rsa"]
 
 [dependencies]
 # Public dependencies (present in the public API).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Compact JWT implementation in Rust
 
-[![Travis Build Status](https://img.shields.io/travis/com/slowli/jwt-compact/master.svg?label=Linux%20Build)](https://travis-ci.com/slowli/jwt-compact) 
+[![Travis Build Status](https://img.shields.io/travis/com/slowli/jwt-compact/master.svg?label=Linux%20Build)](https://travis-ci.com/slowli/jwt-compact)
 [![License: Apache-2.0](https://img.shields.io/github/license/slowli/jwt-compact.svg)](https://github.com/slowli/jwt-compact/blob/master/LICENSE)
 ![rust 1.45.0+ required](https://img.shields.io/badge/rust-1.45.0+-blue.svg?label=Required%20Rust)
 [![Dependencies status](https://img.shields.io/librariesio/github/slowli/jwt-compact)](https://libraries.io/github/slowli/jwt-compact)
@@ -25,10 +25,10 @@ See the crate docs for the examples of usage.
   with the secp256k1 elliptic curve. Both curves are widely used in crypto community
   and believed to be securely generated (there are some doubts about parameter generation
   for elliptic curves used in standard `ES*` algorithms).
+- Optional support of RSA (`RS*` and `PS*` algorithms).
 
 ### Missing features
 
-- Support of RSA (`RS*` and `PS*`) and standard elliptic curve (`ES*`) algorithms.
 - Built-in checks of some claims (e.g., `iss` – the token issuer).
   This is intentional: depending on the use case, such claims can have different semantics
   and thus be represented by different datatypes (e.g., `iss` may be a human-readable short ID,

--- a/src/alg.rs
+++ b/src/alg.rs
@@ -26,4 +26,6 @@ pub use self::es256k::Es256k;
 pub use self::generic::{SigningKey, VerifyingKey};
 pub use self::hmacs::*;
 #[cfg(feature = "rsa")]
-pub use self::rsa::{Padding, Rsa, RsaSigningKey, RsaVerifyingKey};
+pub use self::rsa::{
+    ModulusBits, ModulusBitsError, RSAPrivateKey, RSAPublicKey, Rsa, RsaSignature,
+};

--- a/src/alg.rs
+++ b/src/alg.rs
@@ -12,6 +12,8 @@ mod eddsa_compact;
 mod eddsa_dalek;
 #[cfg(feature = "exonum-crypto")]
 mod eddsa_sodium;
+#[cfg(feature = "rsa")]
+mod rsa;
 
 #[cfg(feature = "ed25519-compact")]
 pub use self::eddsa_compact::*;
@@ -23,3 +25,5 @@ pub use self::eddsa_sodium::Ed25519;
 pub use self::es256k::Es256k;
 pub use self::generic::{SigningKey, VerifyingKey};
 pub use self::hmacs::*;
+#[cfg(feature = "rsa")]
+pub use self::rsa::{Padding, Rsa, RsaSigningKey, RsaVerifyingKey};

--- a/src/alg/rsa.rs
+++ b/src/alg/rsa.rs
@@ -1,0 +1,270 @@
+use rand_core::{CryptoRng, RngCore};
+use rsa::{hash::Hash, BigUint, PaddingScheme, PublicKey, RSAPrivateKey, RSAPublicKey};
+use sha2::{Digest, Sha256, Sha384, Sha512};
+use thiserror::Error;
+
+use std::borrow::Cow;
+
+use crate::{Algorithm, AlgorithmSignature};
+
+/// Errors that may occur during token parsing.
+#[derive(Debug, Error)]
+pub enum RsaError {
+    #[error("Unsupported signature length")]
+    UnsupportedSignatureLength,
+    #[error("Unsupported modulus size")]
+    UnsupportedModulusSize,
+    #[error("Invalid key: {0}")]
+    InvalidKey(rsa::errors::Error),
+    #[error("Key generation error: {0}")]
+    KeygenError(rsa::errors::Error),
+}
+
+#[derive(Debug)]
+pub struct Signature(Vec<u8>);
+
+impl AlgorithmSignature for Signature {
+    fn try_from_slice(bytes: &[u8]) -> anyhow::Result<Self> {
+        match bytes.len() {
+            256 | 384 | 512 => Ok(Signature(bytes.to_vec())),
+            _ => Err(RsaError::UnsupportedSignatureLength.into()),
+        }
+    }
+
+    fn as_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.0.clone())
+    }
+}
+
+/// RSA padding algorithm.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Padding {
+    /// PKCS1v1.5
+    Pkcs1v15,
+    /// PSS
+    Pss,
+}
+
+/// An RSA public key.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RsaVerifyingKey(RSAPublicKey);
+
+impl AsRef<RSAPublicKey> for RsaVerifyingKey {
+    fn as_ref(&self) -> &RSAPublicKey {
+        &self.0
+    }
+}
+
+impl RsaVerifyingKey {
+    /// Create a verification key from a DER-encoded set of the parameters.
+    pub fn from_der(der: &[u8]) -> anyhow::Result<RsaVerifyingKey> {
+        match RSAPublicKey::from_pkcs8(&der) {
+            Err(e) => Err(RsaError::InvalidKey(e).into()),
+            Ok(key) => Ok(RsaVerifyingKey(key)),
+        }
+    }
+
+    /// Create a verification key from a modulus and a public exponent.
+    pub fn from_components(n: &[u8], e: &[u8]) -> anyhow::Result<RsaVerifyingKey> {
+        let n = BigUint::from_bytes_be(n);
+        let e = BigUint::from_bytes_be(e);
+        match RSAPublicKey::new(n, e) {
+            Err(e) => Err(RsaError::InvalidKey(e).into()),
+            Ok(key) => Ok(RsaVerifyingKey(key)),
+        }
+    }
+}
+
+/// An RSA signing key.
+#[derive(Debug)]
+pub struct RsaSigningKey(RSAPrivateKey);
+
+impl AsRef<RSAPrivateKey> for RsaSigningKey {
+    fn as_ref(&self) -> &RSAPrivateKey {
+        &self.0
+    }
+}
+
+impl RsaSigningKey {
+    /// Create a signing key from a DER-encoded set of the parameters.
+    pub fn from_der(der: &[u8]) -> anyhow::Result<RsaSigningKey> {
+        match RSAPrivateKey::from_pkcs8(&der) {
+            Err(e) => Err(RsaError::InvalidKey(e).into()),
+            Ok(key) => {
+                key.validate().map_err(RsaError::InvalidKey)?;
+                Ok(RsaSigningKey(key))
+            }
+        }
+    }
+
+    /// Convert a signing key to a verification key.
+    pub fn to_verifying_key(&self) -> RsaVerifyingKey {
+        RsaVerifyingKey(RSAPublicKey::from(&self.0))
+    }
+}
+
+/// Integrity algorithm using digital signatures on RSA-PKCS1v1.5 and SHA-256.
+///
+/// The name of the algorithm is specified as `RS256` as per the [IANA registry].
+///
+/// *This type is available if the crate is built with the `rsa` feature.*
+///
+/// [IANA registry]: https://www.iana.org/assignments/jose/jose.xhtml
+#[derive(Debug)]
+pub struct Rsa {
+    hash_alg: Hash,
+    padding_alg: Padding,
+}
+
+impl Rsa {
+    /// Create an instance using a specific hash function and padding
+    pub fn new(hash_alg: Hash, padding_alg: Padding) -> Self {
+        Rsa {
+            hash_alg,
+            padding_alg,
+        }
+    }
+}
+
+impl Algorithm for Rsa {
+    type SigningKey = RsaSigningKey;
+    type VerifyingKey = RsaVerifyingKey;
+    type Signature = Signature;
+
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed(self.name())
+    }
+
+    fn sign(&self, signing_key: &Self::SigningKey, message: &[u8]) -> Self::Signature {
+        self.sign(signing_key, message)
+    }
+
+    fn verify_signature(
+        &self,
+        signature: &Self::Signature,
+        verifying_key: &Self::VerifyingKey,
+        message: &[u8],
+    ) -> bool {
+        self.verify_signature(signature, verifying_key, message)
+    }
+}
+
+impl Rsa {
+    fn hash(&self, message: &[u8]) -> Box<[u8]> {
+        match self.hash_alg {
+            Hash::SHA2_256 => {
+                let h: [u8; 32] = *(Sha256::digest(message).as_ref());
+                Box::new(h)
+            }
+            Hash::SHA2_384 => {
+                let mut h = [0u8; 48];
+                h.copy_from_slice(Sha384::digest(message).as_ref());
+                Box::new(h)
+            }
+            Hash::SHA2_512 => {
+                let mut h = [0u8; 64];
+                h.copy_from_slice(Sha512::digest(message).as_ref());
+                Box::new(h)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn padding_scheme(&self) -> PaddingScheme {
+        match self.padding_alg {
+            Padding::Pkcs1v15 => PaddingScheme::new_pkcs1v15_sign(Some(self.hash_alg)),
+            Padding::Pss => {
+                let rng = rand_core::OsRng {};
+                match self.hash_alg {
+                    Hash::SHA2_256 => PaddingScheme::new_pss::<Sha256, _>(rng),
+                    Hash::SHA2_384 => PaddingScheme::new_pss::<Sha384, _>(rng),
+                    Hash::SHA2_512 => PaddingScheme::new_pss::<Sha512, _>(rng),
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match (self.padding_alg, self.hash_alg) {
+            (Padding::Pkcs1v15, Hash::SHA2_256) => "RS256",
+            (Padding::Pkcs1v15, Hash::SHA2_384) => "RS384",
+            (Padding::Pkcs1v15, Hash::SHA2_512) => "RS512",
+            (Padding::Pss, Hash::SHA2_256) => "PS256",
+            (Padding::Pss, Hash::SHA2_384) => "PS384",
+            (Padding::Pss, Hash::SHA2_512) => "PS512",
+            _ => unreachable!(),
+        }
+    }
+
+    fn sign(&self, signing_key: &RsaSigningKey, message: &[u8]) -> Signature {
+        let digest = self.hash(message);
+        Signature(
+            signing_key
+                .as_ref()
+                .sign_blinded(&mut rand_core::OsRng, self.padding_scheme(), &digest)
+                .expect("Unexpected RSA signature failure"),
+        )
+    }
+
+    fn verify_signature(
+        &self,
+        signature: &Signature,
+        verifying_key: &RsaVerifyingKey,
+        message: &[u8],
+    ) -> bool {
+        let digest = self.hash(message);
+        verifying_key
+            .as_ref()
+            .verify(self.padding_scheme(), &digest, &signature.0)
+            .is_ok()
+    }
+
+    /// Generate a new key pair.
+    pub fn generate<R: CryptoRng + RngCore>(
+        &self,
+        rng: &mut R,
+        modulus_bits: usize,
+    ) -> anyhow::Result<(RsaSigningKey, RsaVerifyingKey)> {
+        match modulus_bits {
+            2048 | 3072 | 4096 => {}
+            _ => return Err(RsaError::UnsupportedModulusSize.into()),
+        }
+        let signing_key = match RSAPrivateKey::new(rng, modulus_bits) {
+            Err(e) => return Err(RsaError::KeygenError(e).into()),
+            Ok(key) => RsaSigningKey(key),
+        };
+        let verifying_key = signing_key.to_verifying_key();
+        Ok((signing_key, verifying_key))
+    }
+
+    /// RSA with SHA-256 and PKCS1v1.5 padding
+    pub fn rs256() -> Rsa {
+        Rsa::new(Hash::SHA2_256, Padding::Pkcs1v15)
+    }
+
+    /// RSA with SHA-384 and PKCS1v1.5 padding
+    pub fn rs384() -> Rsa {
+        Rsa::new(Hash::SHA2_384, Padding::Pkcs1v15)
+    }
+
+    /// RSA with SHA-512 and PKCS1v1.5 padding
+    pub fn rs512() -> Rsa {
+        Rsa::new(Hash::SHA2_512, Padding::Pkcs1v15)
+    }
+
+    /// RSA with SHA-256 and PSS padding
+    pub fn ps256() -> Rsa {
+        Rsa::new(Hash::SHA2_256, Padding::Pss)
+    }
+
+    /// RSA with SHA-384 and PSS padding
+    pub fn ps384() -> Rsa {
+        Rsa::new(Hash::SHA2_384, Padding::Pss)
+    }
+
+    /// RSA with SHA-512 and PSS padding
+    pub fn ps512() -> Rsa {
+        Rsa::new(Hash::SHA2_512, Padding::Pss)
+    }
+}

--- a/src/alg/rsa.rs
+++ b/src/alg/rsa.rs
@@ -76,7 +76,7 @@ enum Padding {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ModulusBits {
-    /// 2048 bits. This is the minimum recommended key size as of 2020.
+    /// 2048 bits. This is the minimum recommended key length as of 2020.
     TwoKilobytes,
     /// 3072 bits.
     ThreeKilobytes,
@@ -124,12 +124,14 @@ pub struct ModulusBitsError(());
 /// - `256` / `384` / `512` denote the hash function
 ///
 /// The length of RSA keys is not unequivocally specified by the algorithm; nevertheless,
-/// it **MUST** be at least 2048 bits as per RFC 7518.
+/// it **MUST** be at least 2048 bits as per RFC 7518. To minimize risks of misconfiguration,
+/// this implementation only supports key lengths specified by the [`ModulusBits`] enum.
 ///
 /// *This type is available if the crate is built with the `rsa` feature.*
 ///
 /// [RSA]: https://en.wikipedia.org/wiki/RSA_(cryptosystem)
 /// [RFC 7518]: https://www.rfc-editor.org/rfc/rfc7518.html
+/// [`ModulusBits`]: enum.ModulusBits.html
 #[derive(Debug)]
 pub struct Rsa {
     hash_alg: HashAlg,
@@ -167,17 +169,17 @@ impl Rsa {
         }
     }
 
-    /// RSA with SHA-256 and PKCS1v1.5 padding.
+    /// RSA with SHA-256 and PKCS#1 v1.5 padding.
     pub const fn rs256() -> Rsa {
         Rsa::new(HashAlg::Sha256, Padding::Pkcs1v15)
     }
 
-    /// RSA with SHA-384 and PKCS1v1.5 padding.
+    /// RSA with SHA-384 and PKCS#1 v1.5 padding.
     pub const fn rs384() -> Rsa {
         Rsa::new(HashAlg::Sha384, Padding::Pkcs1v15)
     }
 
-    /// RSA with SHA-512 and PKCS1v1.5 padding.
+    /// RSA with SHA-512 and PKCS#1 v1.5 padding.
     pub const fn rs512() -> Rsa {
         Rsa::new(HashAlg::Sha512, Padding::Pkcs1v15)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,7 @@
 //! | `EdDSA` (Ed25519) | [`ed25519-dalek`] | Pure Rust implementation |
 //! | `EdDSA` (Ed25519) | [`ed25519-compact`] | Compact pure Rust implementation, WASM-compatible |
 //! | `ES256K` | `es256k` | [Rust binding][`secp256k1`] for [`libsecp256k1`] |
-//!
-//! Standard `RS*`, `PS*` and `ES*` algorithms are not (yet?) implemented. The reasons (besides
-//! laziness and non-friendly APIs in the relevant crypto backends) are as follows:
-//!
-//! - RSA algorithms (i.e., `RS*` and `PS*`) are outdated / produce bloated signatures
-//! - Elliptic curves in `ES*` algs use a maybe-something-up-my-sleeve generation procedure
-//!   and thus may be backdoored
+//! | `RS*`, `PS*` (RSA) | [`rsa`] | Uses pure Rust [`rsa`] crate with blinding |
 //!
 //! `EdDSA` and `ES256K` algorithms are non-standard. They both work with elliptic curves
 //! (Curve25519 and secp256k1; both are widely used in crypto community and believed to be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 //! [`ed25519-compact`]: https://crates.io/crates/ed25519-compact
 //! [`secp256k1`]: https://docs.rs/secp256k1/
 //! [`libsecp256k1`]: https://github.com/bitcoin-core/secp256k1
+//! [`rsa`]: https://docs.rs/rsa/
 //! [`Header`]: struct.Header.html
 //! [`Algorithm`]: trait.Algorithm.html
 //!

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -402,3 +402,21 @@ fn es256k_algorithm() {
     let verifying_key_copy: PublicKey = VerifyingKey::from_slice(&verifying_key_bytes).unwrap();
     assert_eq!(verifying_key, verifying_key_copy);
 }
+
+#[cfg(feature = "rsa")]
+#[test]
+fn ps384_algorithm() {
+    let rsa = Rsa::ps384();
+    let mut rng = thread_rng();
+    let (signing_key, verifying_key) = rsa.generate(&mut rng, 2048).unwrap();
+    test_algorithm(&rsa, &signing_key, &verifying_key);
+}
+
+#[cfg(feature = "rsa")]
+#[test]
+fn ps512_algorithm() {
+    let rsa = Rsa::ps384();
+    let mut rng = thread_rng();
+    let (signing_key, verifying_key) = rsa.generate(&mut rng, 2048).unwrap();
+    test_algorithm(&rsa, &signing_key, &verifying_key);
+}

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -1,12 +1,13 @@
 use assert_matches::assert_matches;
 use chrono::{Duration, Utc};
 use hex_buffer_serde::{Hex as _, HexForm};
-use jwt_compact::{alg::*, prelude::*, Algorithm, ValidationError};
-use rand::thread_rng;
+use rand::{seq::index::sample as sample_indexes, thread_rng};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use std::{collections::HashMap, convert::TryFrom};
+
+use jwt_compact::{alg::*, prelude::*, Algorithm, ValidationError};
 
 type Obj = serde_json::Map<String, serde_json::Value>;
 
@@ -204,6 +205,9 @@ fn test_algorithm<A: Algorithm>(
     signing_key: &A::SigningKey,
     verifying_key: &A::VerifyingKey,
 ) {
+    // Maximum number of signature bits mangled.
+    const MAX_MANGLED_BITS: usize = 128;
+
     let claims = create_claims();
 
     // Successful case with a compact token.
@@ -226,7 +230,16 @@ fn test_algorithm<A: Algorithm>(
     let signature = token_string.rsplit('.').next().unwrap();
     let signature_start = token_string.rfind('.').unwrap() + 1;
     let signature = base64::decode_config(signature, base64::URL_SAFE_NO_PAD).unwrap();
-    for i in 0..(signature.len() * 8) {
+    let signature_bits = signature.len() * 8;
+
+    let mangled_bits: Box<dyn Iterator<Item = usize>> = if signature_bits <= MAX_MANGLED_BITS {
+        Box::new(0..signature_bits)
+    } else {
+        let indexes = sample_indexes(&mut thread_rng(), signature_bits, MAX_MANGLED_BITS);
+        Box::new(indexes.into_iter())
+    };
+
+    for i in mangled_bits {
         let mut mangled_signature = signature.clone();
         mangled_signature[i / 8] ^= 1 << (i % 8) as u8;
         let mangled_signature = base64::encode_config(&mangled_signature, base64::URL_SAFE_NO_PAD);
@@ -404,19 +417,219 @@ fn es256k_algorithm() {
 }
 
 #[cfg(feature = "rsa")]
+const RSA_PRIVATE_KEY: &str = r#"
+-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAnzyis1ZjfNB0bBgKFMSvvkTtwlvBsaJq7S5wA+kzeVOVpVWw
+kWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHcaT92whREFpLv9cj5lTeJSibyr/Mr
+m/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIytvHWTxZYEcXLgAXFuUuaS3uF9gEi
+NQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0e+lf4s4OxQawWD79J9/5d3Ry0vbV
+3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWbV6L11BWkpzGXSW4Hv43qa+GSYOD2
+QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9MwIDAQABAoIBACiARq2wkltjtcjs
+kFvZ7w1JAORHbEufEO1Eu27zOIlqbgyAcAl7q+/1bip4Z/x1IVES84/yTaM8p0go
+amMhvgry/mS8vNi1BN2SAZEnb/7xSxbflb70bX9RHLJqKnp5GZe2jexw+wyXlwaM
++bclUCrh9e1ltH7IvUrRrQnFJfh+is1fRon9Co9Li0GwoN0x0byrrngU8Ak3Y6D9
+D8GjQA4Elm94ST3izJv8iCOLSDBmzsPsXfcCUZfmTfZ5DbUDMbMxRnSo3nQeoKGC
+0Lj9FkWcfmLcpGlSXTO+Ww1L7EGq+PT3NtRae1FZPwjddQ1/4V905kyQFLamAA5Y
+lSpE2wkCgYEAy1OPLQcZt4NQnQzPz2SBJqQN2P5u3vXl+zNVKP8w4eBv0vWuJJF+
+hkGNnSxXQrTkvDOIUddSKOzHHgSg4nY6K02ecyT0PPm/UZvtRpWrnBjcEVtHEJNp
+bU9pLD5iZ0J9sbzPU/LxPmuAP2Bs8JmTn6aFRspFrP7W0s1Nmk2jsm0CgYEAyH0X
++jpoqxj4efZfkUrg5GbSEhf+dZglf0tTOA5bVg8IYwtmNk/pniLG/zI7c+GlTc9B
+BwfMr59EzBq/eFMI7+LgXaVUsM/sS4Ry+yeK6SJx/otIMWtDfqxsLD8CPMCRvecC
+2Pip4uSgrl0MOebl9XKp57GoaUWRWRHqwV4Y6h8CgYAZhI4mh4qZtnhKjY4TKDjx
+QYufXSdLAi9v3FxmvchDwOgn4L+PRVdMwDNms2bsL0m5uPn104EzM6w1vzz1zwKz
+5pTpPI0OjgWN13Tq8+PKvm/4Ga2MjgOgPWQkslulO/oMcXbPwWC3hcRdr9tcQtn9
+Imf9n2spL/6EDFId+Hp/7QKBgAqlWdiXsWckdE1Fn91/NGHsc8syKvjjk1onDcw0
+NvVi5vcba9oGdElJX3e9mxqUKMrw7msJJv1MX8LWyMQC5L6YNYHDfbPF1q5L4i8j
+8mRex97UVokJQRRA452V2vCO6S5ETgpnad36de3MUxHgCOX3qL382Qx9/THVmbma
+3YfRAoGAUxL/Eu5yvMK8SAt/dJK6FedngcM3JEFNplmtLYVLWhkIlNRGDwkg3I5K
+y18Ae9n7dHVueyslrb6weq7dTkYDi3iOYRW8HRkIQh06wEdbxt0shTzAJvvCQfrB
+jg/3747WSsf/zBTcHihTRBdAv6OmdhV4/dD5YBfLAkLrd+mX7iE=
+-----END RSA PRIVATE KEY-----
+"#;
+
+#[cfg(feature = "rsa")]
+#[test]
+fn rs256_algorithm() {
+    let rsa = Rsa::rs256();
+    let signing_key = rsa::pem::parse(RSA_PRIVATE_KEY).unwrap();
+    let signing_key = RSAPrivateKey::from_pkcs1(&signing_key.contents).unwrap();
+    signing_key.validate().unwrap();
+    let verifying_key = signing_key.to_public_key();
+    test_algorithm(&rsa, &signing_key, &verifying_key);
+}
+
+#[cfg(feature = "rsa")]
+#[test]
+fn rs256_algorithm_with_generated_keys() {
+    //! Since RSA key generation is very slow in the debug mode, we test generated keys
+    //! for only one JWS algorithm.
+
+    let rsa = Rsa::rs256();
+    let (signing_key, verifying_key) =
+        Rsa::generate(&mut thread_rng(), ModulusBits::TwoKilobytes).unwrap();
+    test_algorithm(&rsa, &signing_key, &verifying_key);
+}
+
+#[cfg(feature = "rsa")]
+#[test]
+fn rs384_algorithm() {
+    let rsa = Rsa::rs384();
+    let signing_key = rsa::pem::parse(RSA_PRIVATE_KEY).unwrap();
+    let signing_key = RSAPrivateKey::from_pkcs1(&signing_key.contents).unwrap();
+    signing_key.validate().unwrap();
+    let verifying_key = signing_key.to_public_key();
+    test_algorithm(&rsa, &signing_key, &verifying_key);
+}
+
+#[cfg(feature = "rsa")]
+#[test]
+fn rs512_algorithm() {
+    let rsa = Rsa::rs512();
+    let signing_key = rsa::pem::parse(RSA_PRIVATE_KEY).unwrap();
+    let signing_key = RSAPrivateKey::from_pkcs1(&signing_key.contents).unwrap();
+    signing_key.validate().unwrap();
+    let verifying_key = signing_key.to_public_key();
+    test_algorithm(&rsa, &signing_key, &verifying_key);
+}
+
+#[cfg(feature = "rsa")]
+#[test]
+fn ps256_algorithm() {
+    let rsa = Rsa::ps256();
+    let signing_key = rsa::pem::parse(RSA_PRIVATE_KEY).unwrap();
+    let signing_key = RSAPrivateKey::from_pkcs1(&signing_key.contents).unwrap();
+    signing_key.validate().unwrap();
+    let verifying_key = signing_key.to_public_key();
+    test_algorithm(&rsa, &signing_key, &verifying_key);
+}
+
+#[cfg(feature = "rsa")]
 #[test]
 fn ps384_algorithm() {
     let rsa = Rsa::ps384();
-    let mut rng = thread_rng();
-    let (signing_key, verifying_key) = rsa.generate(&mut rng, 2048).unwrap();
+    let signing_key = rsa::pem::parse(RSA_PRIVATE_KEY).unwrap();
+    let signing_key = RSAPrivateKey::from_pkcs1(&signing_key.contents).unwrap();
+    signing_key.validate().unwrap();
+    let verifying_key = signing_key.to_public_key();
     test_algorithm(&rsa, &signing_key, &verifying_key);
 }
 
 #[cfg(feature = "rsa")]
 #[test]
 fn ps512_algorithm() {
-    let rsa = Rsa::ps384();
-    let mut rng = thread_rng();
-    let (signing_key, verifying_key) = rsa.generate(&mut rng, 2048).unwrap();
+    let rsa = Rsa::ps512();
+    let signing_key = rsa::pem::parse(RSA_PRIVATE_KEY).unwrap();
+    let signing_key = RSAPrivateKey::from_pkcs1(&signing_key.contents).unwrap();
+    signing_key.validate().unwrap();
+    let verifying_key = signing_key.to_public_key();
     test_algorithm(&rsa, &signing_key, &verifying_key);
+}
+
+#[cfg(feature = "rsa")]
+const RSA_PUBLIC_KEY: &str = r#"
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnzyis1ZjfNB0bBgKFMSv
+vkTtwlvBsaJq7S5wA+kzeVOVpVWwkWdVha4s38XM/pa/yr47av7+z3VTmvDRyAHc
+aT92whREFpLv9cj5lTeJSibyr/Mrm/YtjCZVWgaOYIhwrXwKLqPr/11inWsAkfIy
+tvHWTxZYEcXLgAXFuUuaS3uF9gEiNQwzGTU1v0FqkqTBr4B8nW3HCN47XUu0t8Y0
+e+lf4s4OxQawWD79J9/5d3Ry0vbV3Am1FtGJiJvOwRsIfVChDpYStTcHTCMqtvWb
+V6L11BWkpzGXSW4Hv43qa+GSYOD2QU68Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9
+MwIDAQAB
+-----END PUBLIC KEY-----
+"#;
+
+#[cfg(feature = "rsa")]
+fn test_rsa_reference(rsa: Rsa, token: &str) {
+    let public_key = rsa::pem::parse(RSA_PUBLIC_KEY).unwrap();
+    let public_key = RSAPublicKey::from_pkcs8(&public_key.contents).unwrap();
+    let token = UntrustedToken::try_from(token).unwrap();
+    assert_eq!(token.algorithm(), rsa.name());
+
+    let token = rsa
+        .validate_integrity::<SampleClaims>(&token, &public_key)
+        .unwrap();
+    assert_eq!(token.claims().issued_at.unwrap().timestamp(), 1_516_239_022);
+    assert_eq!(
+        token.claims().custom,
+        SampleClaims {
+            subject: "1234567890".to_owned(),
+            name: "John Doe".to_owned(),
+            admin: true
+        }
+    );
+}
+
+#[cfg(feature = "rsa")]
+#[test]
+fn rs256_reference() {
+    // Generated using https://jwt.io/
+    const TOKEN: &str = "\
+        eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lI\
+        iwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.POstGetfAytaZS82wHcjoTyoqhMyxXiWdR7Nn7A29DN\
+        Sl0EiXLdwJ6xC6AfgZWF1bOsS_TuYI3OG85AmiExREkrS6tDfTQ2B3WXlrr-wp5AokiRbz3_oB4OxG-W9KcEEb\
+        DRcZc0nH3L7LzYptiy1PtAylQGxHTWZXtGz4ht0bAecBgmpdgXMguEIcoqPJ1n3pIWk_dUZegpqx0Lka21H6Xx\
+        UTxiy8OcaarA8zdnPUnV6AmNP3ecFawIFYdvJB_cm-GvpCSbr8G8y_Mllj8f4x9nBH8pQux89_6gUY618iYv7t\
+        uPWBFfEbLxtF2pZS6YC1aSfLQxeNe8djT9YjpvRZA";
+
+    test_rsa_reference(Rsa::rs256(), TOKEN);
+}
+
+#[cfg(feature = "rsa")]
+#[test]
+fn rs384_reference() {
+    // Generated using https://jwt.io/
+    const TOKEN: &str = "\
+        eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lI\
+        iwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.D4kXa3UspFjRA9ys5tsD4YDyxxam3l_XnOb3hMEdPDT\
+        fSLRHPv4HPwxvin-pIkEmfJshXPSK7O4zqSXWAXFO52X-upJjFc_gpGDswctNWpOJeXe1xBgJ--VuGDzUQCqkr\
+        9UBpN-Q7TE5u9cgIVisekSFSH5Ax6aXQC9vCO5LooNFx_WnbTLNZz7FUia9vyJ544kLB7UcacL-_idgRNIWPdd\
+        _d1vvnNGkknIMarRjCsjAEf6p5JGhYZ8_C18g-9DsfokfUfSpKgBR23R8v8ZAAmPPPiJ6MZXkefqE7p3jRbA--\
+        58z5TlHmH9nTB1DYE2872RYvyzG3LoQ-2s93VaVuw";
+
+    test_rsa_reference(Rsa::rs384(), TOKEN);
+}
+
+#[cfg(feature = "rsa")]
+#[test]
+fn rs512_reference() {
+    // Generated using https://jwt.io/
+    const TOKEN: &str = "\
+        eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lI\
+        iwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.JlX3gXGyClTBFciHhknWrjo7SKqyJ5iBO0n-3S2_I7c\
+        IgfaZAeRDJ3SQEbaPxVC7X8aqGCOM-pQOjZPKUJN8DMFrlHTOdqMs0TwQ2PRBmVAxXTSOZOoEhD4ZNCHohYoyf\
+        oDhJDP4Qye_FCqu6POJzg0Jcun4d3KW04QTiGxv2PkYqmB7nHxYuJdnqE3704hIS56pc_8q6AW0WIT0W-nIvwz\
+        aSbtBU9RgaC7ZpBD2LiNE265UBIFraMDF8IAFw9itZSUCTKg1Q-q27NwwBZNGYStMdIBDor2Bsq5ge51EkWajz\
+        Z7ALisVp-bskzUsqUf77ejqX_CBAqkNdH1Zebn93A";
+
+    test_rsa_reference(Rsa::rs512(), TOKEN);
+}
+
+#[cfg(feature = "rsa")]
+#[test]
+fn ps256_reference() {
+    // Generated using https://jwt.io/
+    const TOKEN: &str = "\
+        eyJhbGciOiJQUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lI\
+        iwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.hZnl5amPk_I3tb4O-Otci_5XZdVWhPlFyVRvcqSwnDo\
+        _srcysDvhhKOD01DigPK1lJvTSTolyUgKGtpLqMfRDXQlekRsF4XhAjYZTmcynf-C-6wO5EI4wYewLNKFGGJzH\
+        AknMgotJFjDi_NCVSjHsW3a10nTao1lB82FRS305T226Q0VqNVJVWhE4G0JQvi2TssRtCxYTqzXVt22iDKkXeZ\
+        JARZ1paXHGV5Kd1CljcZtkNZYIGcwnj65gvuCwohbkIxAnhZMJXCLaVvHqv9l-AAUV7esZvkQR1IpwBAiDQJh4\
+        qxPjFGylyXrHMqh5NlT_pWL2ZoULWTg_TJjMO9TuQ";
+
+    test_rsa_reference(Rsa::ps256(), TOKEN);
+}
+
+#[cfg(feature = "rsa")]
+#[test]
+fn ps384_reference() {
+    // Generated using https://jwt.io/
+    const TOKEN: &str = "\
+        eyJhbGciOiJQUzM4NCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lI\
+        iwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.MqF1AKsJkijKnfqEI3VA1OnzAL2S4eIpAuievMgD3tE\
+        FyFMU67gCbg-fxsc5dLrxNwdZEXs9h0kkicJZ70mp6p5vdv-j2ycDKBWg05Un4OhEl7lYcdIsCsB8QUPmstF-l\
+        QWnNqnq3wra1GynJrOXDL27qIaJnnQKlXuayFntBF0j-82jpuVdMaSXvk3OGaOM-7rCRsBcSPmocaAO-uWJEGP\
+        w_OWVaC5RRdWDroPi4YL4lTkDEC-KEvVkqCnFm_40C-T_siXquh5FVbpJjb3W2_YvcqfDRj44TsRrpVhk6ohsH\
+        MNeUad_cxnFnpolIKnaXq_COv35e9EgeQIPAbgIeg";
+
+    test_rsa_reference(Rsa::ps384(), TOKEN);
 }


### PR DESCRIPTION
This adds support for the `rs*` and `ps*` schemes.

JWT and RSA are horrible things.

Unfortunately, popular authentication providers (hi, Okta!) don't support anything but `RS256` for their own tokens.

Makes this of course not part of the default Cargo features.