### PR TITLE
Sketch traits for signing / verifying keys

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --features secp256k1 --all-targets
+          args: --features es256k --all-targets
       - name: Clippy dalek crypto
         uses: actions-rs/clippy-check@v1
         with:
@@ -66,7 +66,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features secp256k1
+          args: --features es256k
       - name: Test dalek crypto
         uses: actions-rs/cargo@v1
         with:
@@ -79,7 +79,7 @@ jobs:
           args: --no-default-features --features ed25519-compact --lib --tests
 
       - name: Check docs
-        run: cargo clean --doc && cargo doc --features secp256k1 --no-deps && cargo deadlinks --dir target/doc
+        run: cargo clean --doc && cargo doc --features es256k --no-deps && cargo deadlinks --dir target/doc
 
   document:
     needs: build
@@ -113,7 +113,7 @@ jobs:
       - name: Build docs
         run: |
           cargo clean --doc && \
-          cargo rustdoc --features secp256k1 -- -Z unstable-options \
+          cargo rustdoc --features es256k -- -Z unstable-options \
             --extern-html-root-url base64=https://docs.rs/base64/~0.12 \
             --extern-html-root-url exonum-crypto=https://docs.rs/exonum-crypto/1.0.0-rc.2 \
             --extern-html-root-url anyhow=https://docs.rs/anyhow/~1.0 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,16 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 - Add the [`ed25519-compact`] backend for Ed25519-based tokens.
 
+- Add `SigningKey` and `VerifyingKey` traits for generic access to cryptographic keys.
+
 ### Changed
 
 - Update dependencies.
 
 - Update minimum supported Rust version due to dependencies.
+
+- `es256k` feature should now be used for access to libsecp256k1 backend instead of
+  `secp256k1`.
 
 ## 0.2.0 - 2020-05-11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ ed25519-dalek = { version = "1.0.0-pre.3", optional = true }
 secp256k1 = { version = "0.17.2", optional = true }
 
 # Private dependencies (not exposed in the public API).
+lazy_static = "1.4.0"
 smallvec = "1.4.0"
 thiserror = "1.0.16"
 zeroize = { version = "1.1", features = ["zeroize_derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/slowli/jwt-compact"
 
 # Enable `ES256K` algorithm in documentation on `docs.rs`.
 [package.metadata.docs.rs]
-features = ["secp256k1"]
+features = ["es256k"]
 
 [dependencies]
 # Public dependencies (present in the public API).
@@ -35,7 +35,7 @@ ed25519-dalek = { version = "1.0.0-pre.3", optional = true }
 secp256k1 = { version = "0.17.2", optional = true }
 
 # Private dependencies (not exposed in the public API).
-lazy_static = "1.4.0"
+lazy_static = { version = "1.4.0", optional = true }
 smallvec = "1.4.0"
 thiserror = "1.0.16"
 zeroize = { version = "1.1", features = ["zeroize_derive"] }
@@ -59,3 +59,4 @@ rand = "0.7.3"
 
 [features]
 default = ["exonum-crypto"]
+es256k = ["secp256k1", "lazy_static"]

--- a/src/alg.rs
+++ b/src/alg.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "secp256k1")]
 mod es256k;
+mod generic;
 mod hmacs;
 // Alternative EdDSA implementations.
 #[cfg(feature = "ed25519-compact")]
@@ -19,4 +20,5 @@ pub use self::eddsa_dalek::Ed25519;
 pub use self::eddsa_sodium::Ed25519;
 #[cfg(feature = "secp256k1")]
 pub use self::es256k::Es256k;
+pub use self::generic::{SigningKey, VerifyingKey};
 pub use self::hmacs::*;

--- a/src/alg.rs
+++ b/src/alg.rs
@@ -1,4 +1,5 @@
-//! Implementations of JWT signing / verification algorithms.
+//! Implementations of JWT signing / verification algorithms. Also contains generic traits
+//! for signing and verifying keys.
 
 #[cfg(feature = "secp256k1")]
 mod es256k;

--- a/src/alg/eddsa_dalek.rs
+++ b/src/alg/eddsa_dalek.rs
@@ -2,7 +2,10 @@ use ed25519_dalek::{Keypair, PublicKey, Signature, Signer, Verifier};
 
 use std::{borrow::Cow, convert::TryFrom};
 
-use crate::{Algorithm, AlgorithmSignature, Renamed};
+use crate::{
+    alg::{SigningKey, VerifyingKey},
+    Algorithm, AlgorithmSignature, Renamed,
+};
 
 impl AlgorithmSignature for Signature {
     fn try_from_slice(bytes: &[u8]) -> anyhow::Result<Self> {
@@ -53,5 +56,29 @@ impl Algorithm for Ed25519 {
         message: &[u8],
     ) -> bool {
         verifying_key.verify(message, signature).is_ok()
+    }
+}
+
+impl VerifyingKey<Ed25519> for PublicKey {
+    fn from_slice(raw: &[u8]) -> anyhow::Result<Self> {
+        Self::from_bytes(raw).map_err(From::from)
+    }
+
+    fn as_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(self.as_ref())
+    }
+}
+
+impl SigningKey<Ed25519> for Keypair {
+    fn from_slice(raw: &[u8]) -> anyhow::Result<Self> {
+        Self::from_bytes(raw).map_err(From::from)
+    }
+
+    fn to_verifying_key(&self) -> PublicKey {
+        self.public
+    }
+
+    fn as_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(self.to_bytes().to_vec())
     }
 }

--- a/src/alg/es256k.rs
+++ b/src/alg/es256k.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use secp256k1::{All, Message, PublicKey, Secp256k1, SecretKey, Signature};
 use sha2::{
     digest::{generic_array::typenum::U32, Digest},
@@ -6,7 +7,10 @@ use sha2::{
 
 use std::{borrow::Cow, marker::PhantomData};
 
-use crate::{Algorithm, AlgorithmSignature};
+use crate::{
+    alg::{SigningKey, VerifyingKey},
+    Algorithm, AlgorithmSignature,
+};
 
 impl AlgorithmSignature for Signature {
     fn try_from_slice(slice: &[u8]) -> anyhow::Result<Self> {
@@ -94,5 +98,37 @@ where
         self.context
             .verify(&message, signature, verifying_key)
             .is_ok()
+    }
+}
+
+/// This implementation initializes a `libsecp256k1` context once on the first call to
+/// `to_verifying_key` if it was not initialized previously.
+impl SigningKey<Es256k> for SecretKey {
+    fn from_slice(raw: &[u8]) -> anyhow::Result<Self> {
+        Self::from_slice(raw).map_err(From::from)
+    }
+
+    fn to_verifying_key(&self) -> PublicKey {
+        lazy_static! {
+            static ref CONTEXT: Secp256k1<All> = Secp256k1::new();
+        }
+        PublicKey::from_secret_key(&CONTEXT, self)
+    }
+
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(&self[..])
+    }
+}
+
+impl VerifyingKey<Es256k> for PublicKey {
+    fn from_slice(raw: &[u8]) -> anyhow::Result<Self> {
+        Self::from_slice(raw).map_err(From::from)
+    }
+
+    /// Serializes the key as a 33-byte compressed form, as per the [`serialize()`] method.
+    ///
+    /// [`serialize()`]: https://docs.rs/secp256k1/0.17.2/secp256k1/key/struct.PublicKey.html
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(self.serialize().to_vec())
     }
 }

--- a/src/alg/generic.rs
+++ b/src/alg/generic.rs
@@ -1,0 +1,47 @@
+//! Generic traits providing uniform interfaces for a certain cryptosystem
+//! across different backends.
+
+use std::borrow::Cow;
+
+use crate::Algorithm;
+
+/// Verifying key for a specific public-key signature cryptosystem.
+///
+/// This trait provides a uniform interface for different backends / implementations
+/// of the same cryptosystem.
+pub trait VerifyingKey<T>: Sized
+where
+    T: Algorithm<VerifyingKey = Self>,
+{
+    /// Creates a key from `raw` bytes. Returns an error if the bytes do not represent
+    /// a valid key.
+    fn from_slice(raw: &[u8]) -> anyhow::Result<Self>;
+
+    /// Returns the key as raw bytes.
+    ///
+    /// Implementations should return `Cow::Borrowed` whenever possible (that is, if the bytes
+    /// are actually stored within the implementing data structure).
+    fn as_bytes(&self) -> Cow<[u8]>;
+}
+
+/// Signing key for a specific public-key signature cryptosystem.
+///
+/// This trait provides a uniform interface for different backends / implementations
+/// of the same cryptosystem.
+pub trait SigningKey<T>: Sized
+where
+    T: Algorithm<SigningKey = Self>,
+{
+    /// Creates a key from `raw` bytes. Returns an error if the bytes do not represent
+    /// a valid key.
+    fn from_slice(raw: &[u8]) -> anyhow::Result<Self>;
+
+    /// Converts a signing key to a verification key.
+    fn to_verifying_key(&self) -> T::VerifyingKey;
+
+    /// Returns the key as raw bytes.
+    ///
+    /// Implementations should return `Cow::Borrowed` whenever possible (that is, if the bytes
+    /// are actually stored within the implementing data structure).
+    fn as_bytes(&self) -> Cow<[u8]>;
+}

--- a/src/alg/generic.rs
+++ b/src/alg/generic.rs
@@ -5,7 +5,8 @@ use std::borrow::Cow;
 
 use crate::Algorithm;
 
-/// Verifying key for a specific public-key signature cryptosystem.
+/// Verifying key for a specific signature cryptosystem. In the case of public-key cryptosystems,
+/// this is a public key.
 ///
 /// This trait provides a uniform interface for different backends / implementations
 /// of the same cryptosystem.
@@ -24,7 +25,8 @@ where
     fn as_bytes(&self) -> Cow<[u8]>;
 }
 
-/// Signing key for a specific public-key signature cryptosystem.
+/// Signing key for a specific signature cryptosystem. In the case of public-key cryptosystems,
+/// this is a private key.
 ///
 /// This trait provides a uniform interface for different backends / implementations
 /// of the same cryptosystem.

--- a/src/alg/hmacs.rs
+++ b/src/alg/hmacs.rs
@@ -8,7 +8,10 @@ use zeroize::Zeroize;
 
 use std::{borrow::Cow, fmt};
 
-use crate::{Algorithm, AlgorithmSignature};
+use crate::{
+    alg::{SigningKey, VerifyingKey},
+    Algorithm, AlgorithmSignature,
+};
 
 macro_rules! define_hmac_key {
     (
@@ -213,3 +216,35 @@ impl Algorithm for Hs512 {
         verifying_key.hmac(message) == *signature
     }
 }
+
+macro_rules! impl_key_traits {
+    ($key:ident<$alg:ident>) => {
+        impl SigningKey<$alg> for $key {
+            fn from_slice(raw: &[u8]) -> anyhow::Result<Self> {
+                Ok(Self::from(raw))
+            }
+
+            fn to_verifying_key(&self) -> Self {
+                self.clone()
+            }
+
+            fn as_bytes(&self) -> Cow<'_, [u8]> {
+                Cow::Borrowed(self.as_ref())
+            }
+        }
+
+        impl VerifyingKey<$alg> for $key {
+            fn from_slice(raw: &[u8]) -> anyhow::Result<Self> {
+                Ok(Self::from(raw))
+            }
+
+            fn as_bytes(&self) -> Cow<'_, [u8]> {
+                Cow::Borrowed(self.as_ref())
+            }
+        }
+    };
+}
+
+impl_key_traits!(Hs256Key<Hs256>);
+impl_key_traits!(Hs384Key<Hs384>);
+impl_key_traits!(Hs512Key<Hs512>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! | `EdDSA` (Ed25519) | [`exonum-crypto`] | [`libsodium`] binding. Enabled by default |
 //! | `EdDSA` (Ed25519) | [`ed25519-dalek`] | Pure Rust implementation |
 //! | `EdDSA` (Ed25519) | [`ed25519-compact`] | Compact pure Rust implementation, WASM-compatible |
-//! | `ES256K` | [`secp256k1`] | Binding for [`libsecp256k1`] |
+//! | `ES256K` | `es256k` | [Rust binding][`secp256k1`] for [`libsecp256k1`] |
 //!
 //! Standard `RS*`, `PS*` and `ES*` algorithms are not (yet?) implemented. The reasons (besides
 //! laziness and non-friendly APIs in the relevant crypto backends) are as follows:

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -390,4 +390,15 @@ fn es256k_algorithm() {
     let verifying_key = PublicKey::from_secret_key(&context, &signing_key);
     let es256k: Es256k<sha2::Sha256> = Es256k::new(context);
     test_algorithm(&es256k, &signing_key, &verifying_key);
+
+    // Test correctness of `SigningKey` / `VerifyingKey` trait implementations.
+    let signing_key_bytes = SigningKey::as_bytes(&signing_key);
+    let signing_key_copy: SecretKey = SigningKey::from_slice(&signing_key_bytes).unwrap();
+    assert_eq!(signing_key, signing_key_copy);
+    assert_eq!(verifying_key, signing_key.to_verifying_key());
+
+    let verifying_key_bytes = verifying_key.as_bytes();
+    assert_eq!(verifying_key_bytes.len(), 33);
+    let verifying_key_copy: PublicKey = VerifyingKey::from_slice(&verifying_key_bytes).unwrap();
+    assert_eq!(verifying_key, verifying_key_copy);
 }


### PR DESCRIPTION
One possible solution to #12. The common signing / verifying key functionality is expressed via the corresponding traits, which are tied to an `Algorithm` via a generic param.