### PR TITLE
Make more types non-exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   use a custom clock, which could be useful for testing or if there is no access
   to the system clock.
 
+- Make `Header`, `Claims`, `TimeOptions`, and error types non-exhaustive.
+
 ## 0.2.0 - 2020-05-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - `es256k` feature should now be used for access to libsecp256k1 backend instead of
   `secp256k1`.
 
-- Rework time-related validation logic. It is now possible to use a new `Leeway` type
-  (a wrapper around `chrono::Duration`) in place of `TimeOptions` if there is access
+- Rework time-related token creation / validation logic. It is now possible to
+  use a custom clock, which could be useful for testing or if there is no access
   to the system clock.
 
 ## 0.2.0 - 2020-05-11

--- a/e2e-tests/wasm/src/lib.rs
+++ b/e2e-tests/wasm/src/lib.rs
@@ -68,7 +68,7 @@ where
     T::SigningKey: SigningKey<T>,
 {
     let secret_key = <T::SigningKey>::from_slice(secret_key).map_err(to_js_error)?;
-    let claims = Claims::new(claims).set_duration(Duration::hours(1));
+    let claims = Claims::new(claims).set_duration(&TimeOptions::default(), Duration::hours(1));
 
     let token = T::default()
         .token(Header::default(), &claims, &secret_key)
@@ -126,7 +126,7 @@ pub fn create_rsa_token(
     let private_key = RSAPrivateKey::from_pkcs8(&private_key).map_err(to_js_error)?;
 
     let claims: SampleClaims = claims.into_serde().map_err(to_js_error)?;
-    let claims = Claims::new(claims).set_duration(Duration::hours(1));
+    let claims = Claims::new(claims).set_duration(&TimeOptions::default(), Duration::hours(1));
 
     let token = Rsa::with_name(alg)
         .token(Header::default(), &claims, &private_key)

--- a/e2e-tests/wasm/src/lib.rs
+++ b/e2e-tests/wasm/src/lib.rs
@@ -14,7 +14,7 @@ use core::{convert::TryFrom, fmt};
 use jwt_compact::alg::RSAPrivateKey;
 use jwt_compact::{
     alg::{Ed25519, Hs256, Hs384, Hs512, RSAPublicKey, Rsa, SigningKey, VerifyingKey},
-    Algorithm, AlgorithmExt, Claims, Header, Leeway, Token, UntrustedToken,
+    Algorithm, AlgorithmExt, Claims, Header, TimeOptions, Token, UntrustedToken,
 };
 
 #[wasm_bindgen]
@@ -43,7 +43,7 @@ fn to_js_error(e: impl fmt::Display) -> Error {
 fn extract_claims(token: &Token<SampleClaims>) -> Result<&SampleClaims, JsValue> {
     Ok(&token
         .claims()
-        .validate_expiration(Leeway::default())
+        .validate_expiration(&TimeOptions::default())
         .map_err(to_js_error)?
         .custom)
 }

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -4,41 +4,38 @@ use serde::{Deserialize, Serialize};
 use crate::ValidationError;
 
 /// Time-related validation options.
-///
-/// If the `clock` feature is enabled (and it is enabled by default), [`Leeway`] can be used
-/// instead of `TimeOptions` for checks, since it will implement `Into<TimeOptions>`.
 #[derive(Debug, Clone, Copy)]
-pub struct TimeOptions {
+#[non_exhaustive]
+pub struct TimeOptions<F = fn() -> DateTime<Utc>> {
     /// Leeway to use during validation.
     pub leeway: Duration,
-    /// Current time to check against.
-    pub current_time: DateTime<Utc>,
+    /// Source of the current timestamps.
+    pub clock_fn: F,
 }
 
-/// Leeway for time-related validation checks.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Leeway(pub Duration);
-
-impl Leeway {
-    /// Creates a leeway measured in seconds.
-    pub fn seconds(seconds: u32) -> Self {
-        Self(Duration::seconds(i64::from(seconds)))
+impl<F: Fn() -> DateTime<Utc>> TimeOptions<F> {
+    /// Creates options based on the specified time leeway and clock function.
+    pub fn new(leeway: Duration, clock_fn: F) -> Self {
+        Self { leeway, clock_fn }
     }
 }
 
-impl Default for Leeway {
-    fn default() -> Self {
-        Self(Duration::seconds(60))
+impl TimeOptions {
+    /// Creates options based on the specified time leeway. The clock source is [`Utc::now()`].
+    #[cfg(feature = "clock")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
+    pub fn from_leeway(leeway: Duration) -> Self {
+        Self {
+            leeway,
+            clock_fn: Utc::now,
+        }
     }
 }
 
 #[cfg(feature = "clock")]
-impl From<Leeway> for TimeOptions {
-    fn from(leeway: Leeway) -> TimeOptions {
-        Self {
-            leeway: leeway.0,
-            current_time: Utc::now(),
-        }
+impl Default for TimeOptions {
+    fn default() -> Self {
+        Self::from_leeway(Duration::seconds(60))
     }
 }
 
@@ -146,14 +143,13 @@ impl<T> Claims<T> {
     ///
     /// This method will return an error if the claims do not feature an expiration date,
     /// or if it is in the past (subject to the provided `options`).
-    pub fn validate_expiration(
-        &self,
-        options: impl Into<TimeOptions>,
-    ) -> Result<&Self, ValidationError> {
-        let options = options.into();
+    pub fn validate_expiration<F>(&self, options: &TimeOptions<F>) -> Result<&Self, ValidationError>
+    where
+        F: Fn() -> DateTime<Utc>,
+    {
         self.expiration_date
             .map_or(Err(ValidationError::NoClaim), |expiration| {
-                if options.current_time > expiration + options.leeway {
+                if (options.clock_fn)() > expiration + options.leeway {
                     Err(ValidationError::Expired)
                 } else {
                     Ok(self)
@@ -165,14 +161,13 @@ impl<T> Claims<T> {
     ///
     /// This method will return an error if the claims do not feature a maturity date,
     /// or if it is in the future (subject to the provided `options`).
-    pub fn validate_maturity(
-        &self,
-        options: impl Into<TimeOptions>,
-    ) -> Result<&Self, ValidationError> {
-        let options = options.into();
+    pub fn validate_maturity<F>(&self, options: &TimeOptions<F>) -> Result<&Self, ValidationError>
+    where
+        F: Fn() -> DateTime<Utc>,
+    {
         self.not_before
             .map_or(Err(ValidationError::NoClaim), |not_before| {
-                if options.current_time < not_before - options.leeway {
+                if (options.clock_fn)() < not_before - options.leeway {
                     Err(ValidationError::NotMature)
                 } else {
                     Ok(self)
@@ -251,53 +246,60 @@ mod tests {
     #[test]
     fn expired_claim() {
         let mut claims = Claims::empty();
+        let time_options = TimeOptions::default();
         assert_matches!(
-            claims.validate_expiration(Leeway::default()).unwrap_err(),
+            claims.validate_expiration(&time_options).unwrap_err(),
             ValidationError::NoClaim
         );
 
         claims.expiration_date = Some(Utc::now() - Duration::hours(1));
         assert_matches!(
-            claims.validate_expiration(Leeway::default()).unwrap_err(),
+            claims.validate_expiration(&time_options).unwrap_err(),
             ValidationError::Expired
         );
 
         claims.expiration_date = Some(Utc::now() - Duration::seconds(10));
         // With the default leeway, this claim is still valid.
-        assert!(claims.validate_expiration(Leeway::default()).is_ok());
+        assert!(claims.validate_expiration(&time_options).is_ok());
         // If we set leeway lower, then the claim will be considered expired.
         assert_matches!(
-            claims.validate_expiration(Leeway::seconds(5)).unwrap_err(),
+            claims
+                .validate_expiration(&TimeOptions::from_leeway(Duration::seconds(5)))
+                .unwrap_err(),
             ValidationError::Expired
         );
         // Same if we set the current time in the past.
-        let options = TimeOptions {
-            leeway: Duration::seconds(3),
-            current_time: claims.expiration_date.unwrap(),
-        };
-        assert!(claims.validate_expiration(options).is_ok());
+        let expiration_date = claims.expiration_date.unwrap();
+        assert!(claims
+            .validate_expiration(&TimeOptions::new(Duration::seconds(3), move || {
+                expiration_date
+            }))
+            .is_ok());
     }
 
     #[test]
     fn immature_claim() {
         let mut claims = Claims::empty();
+        let time_options = TimeOptions::default();
         assert_matches!(
-            claims.validate_maturity(Leeway::default()).unwrap_err(),
+            claims.validate_maturity(&time_options).unwrap_err(),
             ValidationError::NoClaim
         );
 
         claims.not_before = Some(Utc::now() + Duration::hours(1));
         assert_matches!(
-            claims.validate_maturity(Leeway::default()).unwrap_err(),
+            claims.validate_maturity(&time_options).unwrap_err(),
             ValidationError::NotMature
         );
 
         claims.not_before = Some(Utc::now() + Duration::seconds(10));
         // With the default leeway, this claim is still valid.
-        assert!(claims.validate_maturity(Leeway::default()).is_ok());
+        assert!(claims.validate_maturity(&time_options).is_ok());
         // If we set leeway lower, then the claim will be considered expired.
         assert_matches!(
-            claims.validate_maturity(Leeway::seconds(5)).unwrap_err(),
+            claims
+                .validate_maturity(&TimeOptions::from_leeway(Duration::seconds(5)))
+                .unwrap_err(),
             ValidationError::NotMature
         );
     }

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -4,6 +4,25 @@ use serde::{Deserialize, Serialize};
 use crate::ValidationError;
 
 /// Time-related options for token creation and validation.
+///
+/// If the `clock` crate feature is on (and it's on by default), `TimeOptions` can be created
+/// using the `Default` impl or [`Self::from_leeway()`]. If the feature is off,
+/// you can still create options using [a generic constructor](Self::new).
+///
+/// # Examples
+///
+/// ```
+/// # use chrono::{Duration, Utc};
+/// # use jwt_compact::TimeOptions;
+/// // Default options.
+/// let default_options = TimeOptions::default();
+/// let options_with_custom_leeway =
+///     TimeOptions::from_leeway(Duration::seconds(5));
+/// // Options that have a fixed time. Can be useful for testing.
+/// let clock_time = Utc::now();
+/// let options_with_stopped_clock =
+///     TimeOptions::new(Duration::seconds(10), move || clock_time);
+/// ```
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct TimeOptions<F = fn() -> DateTime<Utc>> {

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -54,6 +54,7 @@ pub struct Empty {}
 ///
 /// [JWT spec]: https://tools.ietf.org/html/rfc7519#section-4.1
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Claims<T> {
     /// Expiration date of the token.
     #[serde(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,10 +89,7 @@
 //! // Create a symmetric HMAC key, which will be used both to create and verify tokens.
 //! let key = Hs256Key::from(b"super_secret_key_donut_steel" as &[_]);
 //! // Create a token.
-//! let header = Header {
-//!     key_id: Some("my-key".to_owned()),
-//!     ..Default::default()
-//! };
+//! let header = Header::default().with_key_id("my-key");
 //! let claims = Claims::new(CustomClaims { subject: "alice".to_owned() })
 //!     .set_duration_and_issuance(Duration::days(7))
 //!     .set_not_before(Utc::now() - Duration::hours(1));
@@ -477,7 +474,18 @@ impl<A: Algorithm> AlgorithmExt for A {
 /// the verifying key. Since these values will be provided by the adversary in the case of
 /// an attack, they require additional verification (e.g., a provided certificate might
 /// be checked against the list of "acceptable" certificate authorities).
+///
+/// A `Header` can be created using `Default` implementation, which does not set any fields.
+/// For added fluency, you may use `with_*` methods:
+///
+/// ```
+/// # use jwt_compact::Header;
+/// let header = Header::default()
+///     .with_key_id("my-key-id")
+///     .with_certificate_thumbprint("thumbprint");
+/// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Header {
     /// URL of the JSON Web Key Set containing the key that has signed the token.
     /// This field is renamed to `jku` for serialization.
@@ -502,6 +510,41 @@ pub struct Header {
     /// Application-specific signature type. This field is renamed to `typ` for serialization.
     #[serde(rename = "typ", default, skip_serializing_if = "Option::is_none")]
     pub signature_type: Option<String>,
+}
+
+impl Header {
+    /// Sets the `key_set_url` field for this instance.
+    pub fn with_key_set_url(mut self, key_set_url: impl Into<String>) -> Self {
+        self.key_set_url = Some(key_set_url.into());
+        self
+    }
+
+    /// Sets the `key_id` field for this instance.
+    pub fn with_key_id(mut self, key_id: impl Into<String>) -> Self {
+        self.key_id = Some(key_id.into());
+        self
+    }
+
+    /// Sets the `certificate_url` field for this instance.
+    pub fn with_certificate_url(mut self, certificate_url: impl Into<String>) -> Self {
+        self.certificate_url = Some(certificate_url.into());
+        self
+    }
+
+    /// Sets the `certificate_thumbprint` field for this instance.
+    pub fn with_certificate_thumbprint(
+        mut self,
+        certificate_thumbprint: impl Into<String>,
+    ) -> Self {
+        self.certificate_thumbprint = Some(certificate_thumbprint.into());
+        self
+    }
+
+    /// Sets the `signature_type` field for this instance.
+    pub fn with_signature_type(mut self, signature_type: impl Into<String>) -> Self {
+        self.signature_type = Some(signature_type.into());
+        self
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,8 @@
 //! // Validate additional conditions.
 //! token
 //!     .claims()
-//!     .validate_expiration(Leeway::default())?
-//!     .validate_maturity(Leeway::seconds(15))?;
+//!     .validate_expiration(&TimeOptions::default())?
+//!     .validate_maturity(&TimeOptions::from_leeway(Duration::seconds(15)))?;
 //! // Now, we can extract information from the token (e.g., its subject).
 //! let subject = &token.claims().custom.subject;
 //! assert_eq!(subject, "alice");
@@ -147,7 +147,7 @@
 //! // Parse the compact token.
 //! let token = UntrustedToken::try_from(compact_token.as_str())?;
 //! let token: Token<CustomClaims> = Hs256.validate_integrity(&token, &key)?;
-//! token.claims().validate_expiration(Leeway::default())?;
+//! token.claims().validate_expiration(&TimeOptions::default())?;
 //! // Now, we can extract information from the token (e.g., its subject).
 //! assert_eq!(token.claims().custom.subject, [111; 32]);
 //! # Ok(())
@@ -197,12 +197,12 @@ mod alloc {
 /// Prelude to neatly import all necessary stuff from the crate.
 pub mod prelude {
     pub use crate::{
-        AlgorithmExt as _, Claims, Header, Leeway, TimeOptions, Token, UntrustedToken,
+        AlgorithmExt as _, Claims, Header, TimeOptions, Token, UntrustedToken,
     };
 }
 
 pub use crate::{
-    claims::{Claims, Empty, Leeway, TimeOptions},
+    claims::{Claims, Empty, TimeOptions},
     error::{CreationError, ParseError, ValidationError},
 };
 
@@ -626,7 +626,7 @@ impl<T> Token<T> {
 /// let array: GenericArray<u8, typenum::U32> = signed.signature.into_bytes();
 /// // Token itself is available via `token` field.
 /// let claims = signed.token.claims();
-/// claims.validate_expiration(Leeway::default())?;
+/// claims.validate_expiration(&TimeOptions::default())?;
 /// // Process the claims...
 /// # Ok(())
 /// # } // end main()

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -303,12 +303,10 @@ fn create_claims() -> Claims<CompactClaims> {
     let now = Utc.ymd(2020, 9, 1).and_hms(10, 0, 0);
     let now = now - Duration::nanoseconds(i64::from(now.timestamp_subsec_nanos()));
 
-    Claims {
-        issued_at: Some(now),
-        expiration_date: Some(now + Duration::days(7)),
-        not_before: None,
-        custom: CompactClaims { subject: [1; 32] },
-    }
+    let mut claims = Claims::new(CompactClaims { subject: [1; 32] });
+    claims.issued_at = Some(now);
+    claims.expiration_date = Some(now + Duration::days(7));
+    claims
 }
 
 #[test]


### PR DESCRIPTION
Makes `Header`, `Claims` and `TimeOptions` non-exhaustive. Also, `TimeOptions` logic is reworked, allowing to specify a clock function (`fn() -> DateTime<Utc>`) instead of a specific timestamp.

closes #24