### PR TITLE
Use `const-decoder` crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,21 +31,21 @@ jobs:
           toolchain: 1.45.0
           override: true
 
-      - name: Run tests
+      - name: Build with ES256K & RSA
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: -p jwt-compact --features es256k,rsa
-      - name: Test dalek crypto
+          command: build
+          args: -p jwt-compact --lib --features es256k,rsa
+      - name: Build with dalek crypto
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: -p jwt-compact --no-default-features --features std,ed25519-dalek --lib --tests
-      - name: Test ed25519-compact
+          command: build
+          args: -p jwt-compact --no-default-features --features std,ed25519-dalek --lib
+      - name: Build with ed25519-compact
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: -p jwt-compact --no-default-features --features std,ed25519-compact --lib --tests
+          command: build
+          args: -p jwt-compact --no-default-features --features std,ed25519-compact --lib
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2020-10-24
+          toolchain: nightly-2021-04-15
           override: true
           components: rustfmt, clippy
           target: thumbv7m-none-eabi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,8 @@ optional = true
 
 [dev-dependencies]
 assert_matches = "1.3"
+const-decoder = "0.1.0"
 hex = "0.4.2"
-hex-literal = "0.3.1"
 hex-buffer-serde = { version = "0.2.0", default-features = false }
 rand = "0.8.3"
 version-sync = "0.9"

--- a/e2e-tests/no-std/Cargo.toml
+++ b/e2e-tests/no-std/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 anyhow = { version = "1.0.34", default-features = false }
 chrono = { version = "0.4.19", default-features = false }
-hex = { version = "0.4.2", default-features = false }
+const-decoder = "0.1.0"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 # Cortex-M dependencies.

--- a/e2e-tests/no-std/src/main.rs
+++ b/e2e-tests/no-std/src/main.rs
@@ -144,5 +144,5 @@ fn main() -> ! {
     main_inner().unwrap();
 
     debug::exit(debug::EXIT_SUCCESS);
-    loop {}
+    unreachable!("Program must exit by this point");
 }

--- a/e2e-tests/no-std/src/main.rs
+++ b/e2e-tests/no-std/src/main.rs
@@ -9,6 +9,7 @@ extern crate alloc;
 use alloc_cortex_m::CortexMHeap;
 use anyhow::anyhow;
 use chrono::{DateTime, Duration, TimeZone, Utc};
+use const_decoder::Decoder;
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln, syscall};
 use panic_halt as _;
@@ -120,21 +121,17 @@ impl TokenChecker {
 const HEAP_SIZE: usize = 16_384;
 
 const HASH_SECRET_KEY: &[u8] = b"super_secret_key_donut_steel";
-
-// We could use something like https://crates.io/crates/binary_macros, but it doesn't work
-// with `no_std`.
-const ED_PRIVATE_KEY_HEX: &str = "9e55d1e1aa1f455b8baad9fdf975503655f8b359d542fa7e4ce84106d625b352\
-     06fac1f22240cffd637ead6647188429fafda9c9cb7eae43386ac17f61115075";
+const ED_PRIVATE_KEY: [u8; 64] = Decoder::Hex.decode(
+    b"9e55d1e1aa1f455b8baad9fdf975503655f8b359d542fa7e4ce84106d625b352\
+     06fac1f22240cffd637ead6647188429fafda9c9cb7eae43386ac17f61115075",
+);
 
 fn main_inner() -> anyhow::Result<()> {
     let token_checker = TokenChecker::new();
     token_checker.roundtrip_alg::<Hs256>(HASH_SECRET_KEY, HASH_SECRET_KEY)?;
     token_checker.roundtrip_alg::<Hs384>(HASH_SECRET_KEY, HASH_SECRET_KEY)?;
     token_checker.roundtrip_alg::<Hs512>(HASH_SECRET_KEY, HASH_SECRET_KEY)?;
-
-    let mut ed_private_key = [0_u8; ED_PRIVATE_KEY_HEX.len() / 2];
-    hex::decode_to_slice(ED_PRIVATE_KEY_HEX, &mut ed_private_key).map_err(|e| anyhow!(e))?;
-    token_checker.roundtrip_alg::<Ed25519>(&ed_private_key, &ed_private_key[32..])
+    token_checker.roundtrip_alg::<Ed25519>(&ED_PRIVATE_KEY, &ED_PRIVATE_KEY[32..])
 }
 
 #[entry]


### PR DESCRIPTION
Should work at least for the no-std test.