### PR TITLE
`k256` support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,6 +98,12 @@ jobs:
           name: "Clippy: ed25519-compact"
           token: ${{ secrets.GITHUB_TOKEN }}
           args: -p jwt-compact --no-default-features --features std,ed25519-compact --all-targets -- -D warnings
+      - name: Clippy k256
+        uses: actions-rs/clippy-check@v1
+        with:
+          name: "Clippy: k256"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -p jwt-compact --no-default-features --features k256 --all-targets -- -D warnings
       - name: Clippy WASM crate
         uses: actions-rs/clippy-check@v1
         with:
@@ -120,6 +126,11 @@ jobs:
         with:
           command: test
           args: -p jwt-compact --no-default-features --features std,ed25519-compact --lib --tests
+      - name: Test k256
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -p jwt-compact --no-default-features --features std,k256 --lib --tests
 
   build-wasm:
     needs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Add basic JSON Web Key (JWK) support. This allows (de)serializing keys from / into
   a uniform format and computing key thumbprints.
 
+- Add ES256K implementation using pure-Rust [`k256`] crate.
+
 ### Changed
 
 - Update dependencies.
@@ -28,6 +30,11 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   for `HS*` algorithms.
 
 - `exonum-crypto` feature is no longer enabled by default.
+
+### Fixed
+
+- Fix ES256K signature verification by accepting high-S signatures, which are still produced
+  by some third-party implementations (e.g., OpenSSL).
 
 ## 0.3.0 - 2020-11-30
 
@@ -93,3 +100,4 @@ The initial release of `jwt-compact`.
 
 [`ed25519-compact`]: https://crates.io/crates/ed25519-compact
 [`rsa`]: https://crates.io/crates/rsa
+[`k256`]: https://crates.io/crates/k256

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,12 @@ zeroize = { version = "1.1", features = ["zeroize_derive"] }
 # Crypto backends (all public dependencies).
 secp256k1 = { version = "0.20", optional = true }
 
+[dependencies.k256]
+version = "0.8.1"
+default-features = false
+features = ["ecdsa"]
+optional = true
+
 [dependencies.exonum-crypto]
 version = "1.0.0"
 default-features = false

--- a/e2e-tests/wasm/Cargo.toml
+++ b/e2e-tests/wasm/Cargo.toml
@@ -35,4 +35,4 @@ getrandom = { package = "getrandom", version = "0.2", features = ["js"] }
 version = "0.3.0"
 path = "../.."
 default-features = false
-features = ["clock", "ed25519-compact", "rsa"]
+features = ["clock", "ed25519-compact", "rsa", "k256"]

--- a/e2e-tests/wasm/src/lib.rs
+++ b/e2e-tests/wasm/src/lib.rs
@@ -12,7 +12,7 @@ use alloc::string::{String, ToString};
 use core::{convert::TryFrom, fmt};
 
 use jwt_compact::{
-    alg::{Ed25519, Hs256, Hs384, Hs512, Rsa},
+    alg::{Ed25519, Es256k, Hs256, Hs384, Hs512, Rsa},
     jwk::{JsonWebKey, JwkError},
     Algorithm, AlgorithmExt, Claims, Header, TimeOptions, Token, UntrustedToken,
 };
@@ -136,4 +136,18 @@ pub fn create_ed_token(claims: &JsValue, private_key: &JsValue) -> Result<String
     let jwk: JsonWebKey<'_> = private_key.into_serde().map_err(to_js_error)?;
     let claims: SampleClaims = claims.into_serde().map_err(to_js_error)?;
     do_create_token(&Ed25519, claims, &jwk)
+}
+
+#[wasm_bindgen(js_name = "verifyEs256kToken")]
+pub fn verify_es256k_token(token: &str, public_key: &JsValue) -> Result<JsValue, JsValue> {
+    let jwk: JsonWebKey<'_> = public_key.into_serde().map_err(to_js_error)?;
+    let token = UntrustedToken::new(token).map_err(to_js_error)?;
+    do_verify_token(&<Es256k>::default(), &token, &jwk)
+}
+
+#[wasm_bindgen(js_name = "createEs256kToken")]
+pub fn create_es256k_token(claims: &JsValue, private_key: &JsValue) -> Result<String, JsValue> {
+    let jwk: JsonWebKey<'_> = private_key.into_serde().map_err(to_js_error)?;
+    let claims: SampleClaims = claims.into_serde().map_err(to_js_error)?;
+    do_create_token(&<Es256k>::default(), claims, &jwk)
 }

--- a/e2e-tests/wasm/test.js
+++ b/e2e-tests/wasm/test.js
@@ -14,6 +14,8 @@ const {
   createHashToken,
   verifyEdToken,
   createEdToken,
+  verifyEs256kToken,
+  createEs256kToken,
 } = require('jwt-compact-wasm');
 
 const payload = {
@@ -77,6 +79,14 @@ async function iteration() {
     keyGenerator: () => generateKeyPair('EdDSA', { crv: 'Ed25519' }),
     signer: createEdToken,
     verifier: verifyEdToken,
+  });
+
+  // ES256K algorithm.
+  await assertRoundTrip({
+    algorithm: 'ES256K',
+    keyGenerator: () => generateKeyPair('ES256K'),
+    signer: createEs256kToken,
+    verifier: verifyEs256kToken,
   });
 }
 

--- a/src/alg.rs
+++ b/src/alg.rs
@@ -5,10 +5,13 @@ use core::{convert::TryFrom, fmt};
 
 use crate::{alloc::Cow, Algorithm};
 
-#[cfg(feature = "secp256k1")]
-mod es256k;
 mod generic;
 mod hmacs;
+// Alternative ES256K implementations.
+#[cfg(feature = "secp256k1")]
+mod es256k;
+#[cfg(feature = "k256")]
+mod k256;
 // Alternative EdDSA implementations.
 #[cfg(feature = "ed25519-compact")]
 mod eddsa_compact;
@@ -29,6 +32,8 @@ pub use self::eddsa_sodium::Ed25519;
 pub use self::es256k::Es256k;
 pub use self::generic::{SigningKey, VerifyingKey};
 pub use self::hmacs::*;
+#[cfg(feature = "k256")]
+pub use self::k256::Es256k;
 #[cfg(feature = "rsa")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 pub use self::rsa::{

--- a/src/alg/eddsa_compact.rs
+++ b/src/alg/eddsa_compact.rs
@@ -1,3 +1,5 @@
+//! `EdDSA` algorithm implementation using the `ed25519-compact` crate.
+
 use ed25519_compact::{KeyPair, Noise, PublicKey, SecretKey, Seed, Signature};
 use rand_core::{CryptoRng, RngCore};
 

--- a/src/alg/eddsa_dalek.rs
+++ b/src/alg/eddsa_dalek.rs
@@ -1,3 +1,5 @@
+//! `EdDSA` algorithm implementation using the `ed25519-dalek` crate.
+
 use ed25519_dalek::{
     Keypair, PublicKey, SecretKey, Signature, Signer, Verifier, PUBLIC_KEY_LENGTH,
     SECRET_KEY_LENGTH,

--- a/src/alg/eddsa_sodium.rs
+++ b/src/alg/eddsa_sodium.rs
@@ -1,3 +1,5 @@
+//! `EdDSA` algorithm implementation using the `exonum-crypto` crate.
+
 use anyhow::format_err;
 use exonum_crypto::{
     gen_keypair_from_seed, sign, verify, PublicKey, SecretKey, Seed, Signature, PUBLIC_KEY_LENGTH,

--- a/src/alg/es256k.rs
+++ b/src/alg/es256k.rs
@@ -6,7 +6,7 @@ use secp256k1::{
     All, Message, PublicKey, Secp256k1, SecretKey, Signature,
 };
 use sha2::{
-    digest::{generic_array::typenum::U32, Digest},
+    digest::{generic_array::typenum::U32, BlockInput, Digest, FixedOutput, Reset, Update},
     Sha256,
 };
 
@@ -47,7 +47,7 @@ pub struct Es256k<D = Sha256> {
 
 impl<D> Default for Es256k<D>
 where
-    D: Digest<OutputSize = U32> + Default,
+    D: BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
 {
     fn default() -> Self {
         Es256k {
@@ -59,11 +59,12 @@ where
 
 impl<D> Es256k<D>
 where
-    D: Digest<OutputSize = U32> + Default,
+    D: BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
 {
     /// Creates a new algorithm instance.
     /// This is a (moderately) expensive operation, so if necessary, the algorithm should
     /// be `clone()`d rather than created anew.
+    #[cfg_attr(docsrs, doc(cfg(feature = "es256k")))]
     pub fn new(context: Secp256k1<All>) -> Self {
         Es256k {
             context,
@@ -74,7 +75,7 @@ where
 
 impl<D> Algorithm for Es256k<D>
 where
-    D: Digest<OutputSize = U32> + Default,
+    D: BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
 {
     type SigningKey = SecretKey;
     type VerifyingKey = PublicKey;

--- a/src/alg/es256k.rs
+++ b/src/alg/es256k.rs
@@ -104,8 +104,15 @@ where
         let message = Message::from_slice(&digest.finalize())
             .expect("failed to convert message to the correct form");
 
+        // Some implementations (e.g., OpenSSL) produce high-S signatures, which
+        // are considered invalid by this implementation. Hence, we perform normalization here.
+        //
+        // See also: https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki
+        let mut normalized_signature = *signature;
+        normalized_signature.normalize_s();
+
         self.context
-            .verify(&message, signature, verifying_key)
+            .verify(&message, &normalized_signature, verifying_key)
             .is_ok()
     }
 }

--- a/src/alg/es256k.rs
+++ b/src/alg/es256k.rs
@@ -1,3 +1,5 @@
+//! `ES256K` algorithm implementation using the `secp256k1` crate.
+
 use lazy_static::lazy_static;
 use secp256k1::{
     constants::{FIELD_SIZE, SECRET_KEY_SIZE, UNCOMPRESSED_PUBLIC_KEY_SIZE},
@@ -37,7 +39,7 @@ impl AlgorithmSignature for Signature {
 /// but it can be set to any cryptographically secure hash function with 32-byte output
 /// (e.g., SHA3-256).
 #[derive(Debug)]
-#[cfg_attr(docsrs, doc(cfg(feature = "es256k")))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "es256k", feature = "k256"))))]
 pub struct Es256k<D = Sha256> {
     context: Secp256k1<All>,
     _digest: PhantomData<D>,

--- a/src/alg/k256.rs
+++ b/src/alg/k256.rs
@@ -1,0 +1,184 @@
+//! `ES256K` algorithm implementation using the `k256` crate.
+
+use k256::{
+    ecdsa::{
+        signature::{DigestSigner, DigestVerifier},
+        Signature, SigningKey, VerifyingKey,
+    },
+    elliptic_curve::sec1::ToEncodedPoint,
+};
+use sha2::{
+    digest::{generic_array::typenum::U32, BlockInput, FixedOutput, Reset, Update},
+    Sha256,
+};
+
+use core::{convert::TryFrom, marker::PhantomData};
+
+use crate::{
+    alg,
+    alloc::Cow,
+    jwk::{JsonWebKey, JwkError, KeyType, SecretBytes},
+    Algorithm, AlgorithmSignature,
+};
+
+impl AlgorithmSignature for Signature {
+    fn try_from_slice(slice: &[u8]) -> anyhow::Result<Self> {
+        Signature::try_from(slice).map_err(|err| anyhow::anyhow!(err))
+    }
+
+    fn as_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(self.as_ref())
+    }
+}
+
+/// Algorithm implementing elliptic curve digital signatures (ECDSA) on the secp256k1 curve.
+///
+/// The algorithm does not fix the choice of the message digest algorithm; instead,
+/// it is provided as a type parameter. SHA-256 is the default parameter value,
+/// but it can be set to any cryptographically secure hash function with 32-byte output
+/// (e.g., SHA3-256).
+#[derive(Debug)]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "es256k", feature = "k256"))))]
+pub struct Es256k<D = Sha256> {
+    _digest: PhantomData<D>,
+}
+
+impl<D> Default for Es256k<D>
+where
+    D: BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
+{
+    fn default() -> Self {
+        Es256k {
+            _digest: PhantomData,
+        }
+    }
+}
+
+impl<D> Es256k<D>
+where
+    D: BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
+{
+    /// Creates a new algorithm instance.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<D> Algorithm for Es256k<D>
+where
+    D: BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
+{
+    type SigningKey = SigningKey;
+    type VerifyingKey = VerifyingKey;
+    type Signature = Signature;
+
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("ES256K")
+    }
+
+    fn sign(&self, signing_key: &Self::SigningKey, message: &[u8]) -> Self::Signature {
+        let mut digest = D::default();
+        digest.update(message);
+        signing_key.sign_digest(digest)
+    }
+
+    fn verify_signature(
+        &self,
+        signature: &Self::Signature,
+        verifying_key: &Self::VerifyingKey,
+        message: &[u8],
+    ) -> bool {
+        let mut digest = D::default();
+        digest.update(message);
+        verifying_key.verify_digest(digest, signature).is_ok()
+    }
+}
+
+impl alg::SigningKey<Es256k> for SigningKey {
+    fn from_slice(raw: &[u8]) -> anyhow::Result<Self> {
+        Self::from_bytes(raw).map_err(|err| anyhow::anyhow!(err))
+    }
+
+    fn to_verifying_key(&self) -> VerifyingKey {
+        self.verify_key()
+    }
+
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(self.to_bytes().to_vec())
+    }
+}
+
+impl alg::VerifyingKey<Es256k> for VerifyingKey {
+    fn from_slice(raw: &[u8]) -> anyhow::Result<Self> {
+        Self::from_sec1_bytes(raw).map_err(|err| anyhow::anyhow!(err))
+    }
+
+    /// Serializes the key as a 33-byte compressed form.
+    fn as_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(self.to_bytes().to_vec())
+    }
+}
+
+fn create_jwk<'a>(pk: &VerifyingKey, sk: Option<&'a SigningKey>) -> JsonWebKey<'a> {
+    let uncompressed = pk.to_encoded_point(false);
+    JsonWebKey::EllipticCurve {
+        curve: "secp256k1".into(),
+        x: Cow::Owned(uncompressed.x().expect("x coord").to_vec()),
+        y: Cow::Owned(uncompressed.y().expect("y coord").to_vec()),
+        secret: sk.map(|sk| SecretBytes::owned(sk.to_bytes().to_vec())),
+    }
+}
+
+impl<'a> From<&'a VerifyingKey> for JsonWebKey<'a> {
+    fn from(key: &'a VerifyingKey) -> JsonWebKey<'a> {
+        create_jwk(key, None)
+    }
+}
+
+impl TryFrom<&JsonWebKey<'_>> for VerifyingKey {
+    type Error = JwkError;
+
+    fn try_from(jwk: &JsonWebKey<'_>) -> Result<Self, Self::Error> {
+        const COORDINATE_SIZE: usize = 32;
+
+        let (x, y) = if let JsonWebKey::EllipticCurve { curve, x, y, .. } = jwk {
+            JsonWebKey::ensure_curve(curve, "secp256k1")?;
+            (x.as_ref(), y.as_ref())
+        } else {
+            return Err(JwkError::key_type(jwk, KeyType::EllipticCurve));
+        };
+        JsonWebKey::ensure_len("x", x, COORDINATE_SIZE)?;
+        JsonWebKey::ensure_len("y", y, COORDINATE_SIZE)?;
+
+        let mut key_bytes = [0_u8; 2 * COORDINATE_SIZE + 1];
+        key_bytes[0] = 4; // uncompressed key marker
+        key_bytes[1..=COORDINATE_SIZE].copy_from_slice(x);
+        key_bytes[(1 + COORDINATE_SIZE)..].copy_from_slice(y);
+        VerifyingKey::from_sec1_bytes(&key_bytes[..])
+            .map_err(|err| JwkError::custom(anyhow::anyhow!(err)))
+    }
+}
+
+impl<'a> From<&'a SigningKey> for JsonWebKey<'a> {
+    fn from(key: &'a SigningKey) -> JsonWebKey<'a> {
+        create_jwk(&key.verify_key(), Some(key))
+    }
+}
+
+impl TryFrom<&JsonWebKey<'_>> for SigningKey {
+    type Error = JwkError;
+
+    fn try_from(jwk: &JsonWebKey<'_>) -> Result<Self, Self::Error> {
+        let sk_bytes = if let JsonWebKey::EllipticCurve { secret, .. } = jwk {
+            secret.as_deref()
+        } else {
+            return Err(JwkError::key_type(jwk, KeyType::EllipticCurve));
+        };
+        let sk_bytes = sk_bytes.ok_or_else(|| JwkError::NoField("d".into()))?;
+        JsonWebKey::ensure_len("d", sk_bytes, 32)?;
+
+        let sk =
+            Self::from_bytes(sk_bytes).map_err(|err| JwkError::custom(anyhow::anyhow!(err)))?;
+        jwk.ensure_key_match(sk)
+    }
+}

--- a/src/alg/k256.rs
+++ b/src/alg/k256.rs
@@ -54,16 +54,6 @@ where
     }
 }
 
-impl<D> Es256k<D>
-where
-    D: BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
-{
-    /// Creates a new algorithm instance.
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl<D> Algorithm for Es256k<D>
 where
     D: BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
@@ -95,7 +85,7 @@ where
         // are considered invalid by this implementation. Hence, we perform normalization here.
         //
         // See also: https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki
-        let mut normalized_signature = signature.clone();
+        let mut normalized_signature = *signature;
         if normalized_signature.normalize_s().is_err() {
             return false;
         }

--- a/src/alg/rsa.rs
+++ b/src/alg/rsa.rs
@@ -1,4 +1,4 @@
-//! RSA-based JWT schemes: `RS*` and `PS*`.
+//! RSA-based JWT algorithms: `RS*` and `PS*`.
 
 pub use rsa::{errors::Error as RsaError, RSAPrivateKey, RSAPublicKey};
 

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -190,8 +190,8 @@ impl<'a> SecretBytes<'a> {
         Self(Cow::Borrowed(bytes))
     }
 
-    #[cfg(feature = "rsa")]
-    pub(crate) fn owned(bytes: Vec<u8>) -> Self {
+    /// Creates secret bytes from an owned `Vec`.
+    pub fn owned(bytes: Vec<u8>) -> Self {
         Self(Cow::Owned(bytes))
     }
 }
@@ -483,6 +483,7 @@ pub struct RsaPrimeFactor<'a> {
 
 #[cfg(any(
     feature = "es256k",
+    feature = "k256",
     feature = "exonum-crypto",
     feature = "ed25519-dalek",
     feature = "ed25519-compact"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,12 @@
 //! | `EdDSA` (Ed25519) | [`ed25519-dalek`] | Pure Rust implementation |
 //! | `EdDSA` (Ed25519) | [`ed25519-compact`] | Compact pure Rust implementation, WASM-compatible |
 //! | `ES256K` | `es256k` | [Rust binding][`secp256k1`] for [`libsecp256k1`] |
+//! | `ES256K` | [`k256`] | Pure Rust implementation |
 //! | `RS*`, `PS*` (RSA) | [`rsa`] | Uses pure Rust [`rsa`] crate with blinding |
 //!
-//! `EdDSA` and `ES256K` algorithms are non-standard. They both work with elliptic curves
+//! `EdDSA` and `ES256K` algorithms are somewhat less frequently supported by JWT implementations
+//! than others since they are recent additions to the JSON Web Algorithms (JWA) suit.
+//! They both work with elliptic curves
 //! (Curve25519 and secp256k1; both are widely used in crypto community and believed to be
 //! securely generated). These algs have 128-bit security, making them an alternative
 //! to `ES256`.
@@ -67,6 +70,7 @@
 //! [`ed25519-compact`]: https://crates.io/crates/ed25519-compact
 //! [`secp256k1`]: https://docs.rs/secp256k1/
 //! [`libsecp256k1`]: https://github.com/bitcoin-core/secp256k1
+//! [`k256`]: https://docs.rs/k256/
 //! [`rsa`]: https://docs.rs/rsa/
 //! [`chrono`]: https://docs.rs/chrono/
 //!

--- a/tests/jwk.rs
+++ b/tests/jwk.rs
@@ -238,8 +238,11 @@ mod rsa_jwk {
 #[cfg(any(feature = "es256k", feature = "k256"))]
 mod es256k {
     use super::*;
+
+    #[cfg(feature = "k256")]
+    use jwt_compact::alg::VerifyingKey;
     use jwt_compact::{
-        alg::{Es256k, SigningKey, VerifyingKey},
+        alg::{Es256k, SigningKey},
         Algorithm,
     };
 


### PR DESCRIPTION
Adds an alternative ES256K implementation using the `k256` crate (pure Rust, WASM-compatible).