### PR TITLE
validate_expiration no longer panics on very large expirations

### DIFF
--- a/src/alg/rsa.rs
+++ b/src/alg/rsa.rs
@@ -76,7 +76,6 @@ enum Padding {
 
 /// Bit length of an RSA key modulus (aka RSA key length).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[allow(clippy::pub_enum_variant_names)] // false alarm
 #[non_exhaustive]
 #[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
 pub enum ModulusBits {

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -175,8 +175,10 @@ impl<T> Claims<T> {
         self.expiration.map_or(
             Err(ValidationError::NoClaim(Claim::Expiration)),
             |expiration| {
-                let expiration = expiration.checked_add_signed(options.leeway);
-                if expiration.is_some() && (options.clock_fn)() > expiration.unwrap() {
+                let expiration_with_leeway = expiration
+                    .checked_add_signed(options.leeway)
+                    .unwrap_or(chrono::MAX_DATETIME);
+                if (options.clock_fn)() > expiration_with_leeway {
                     Err(ValidationError::Expired)
                 } else {
                     Ok(self)


### PR DESCRIPTION
It is possible to create a panic in validate_expiration, if the expiration + leeway cause an overflow.
This patch fixes the problem, and allows for such large expiration values to be used.

For example using `8210298412799` as expiration would make validate_expiration panic.
