### PR TITLE
Update `sha2` and `hmac`

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,3 @@
+# Minimum supported Rust version. Should be consistent with CI and mentions
+# in crate READMEs.
+msrv = "1.51"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,17 +9,6 @@ updates:
     assignees:
       - slowli
 
-  # Need a separate entry since the no-std package is not included
-  # into the root workspace.
-  - package-ecosystem: cargo
-    directory: "/e2e-tests/no-std"
-    schedule:
-      interval: daily
-      time: "03:00"
-    open-pull-requests-limit: 10
-    assignees:
-      - slowli
-
   - package-ecosystem: npm
     directory: "/e2e-tests/wasm"
     schedule:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 # Public dependencies (present in the public API).
 anyhow = { version = "1.0.34", default-features = false }
 base64ct = { version = "~1.1", features = ["alloc"] }
-# ^ base64ct v1.2.0 requires 2021 edition support
+# ^ base64ct v1.2.0+ requires 2021 edition support
 chrono = { version = "0.4.19", default-features = false }
 rand_core = "0.6.2"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
@@ -35,8 +35,8 @@ serde_cbor = { version = "0.11.1", default-features = false, features = ["alloc"
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 # SHA crypto backend (private dependency; re-exported `digest` crate is public).
-hmac = "0.11.0"
-sha2 = { version = "0.9", default-features = false }
+hmac = "0.12.0"
+sha2 = { version = "0.10", default-features = false }
 
 # Private dependencies (not exposed in the public API).
 lazy_static = { version = "1.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ zeroize = { version = "1.1", features = ["zeroize_derive"] }
 secp256k1 = { version = "0.20", optional = true }
 
 [dependencies.k256]
-version = "0.9.4"
+version = "0.10.0"
 default-features = false
 features = ["ecdsa"]
 optional = true
@@ -77,6 +77,14 @@ optional = true
 default-features = false
 features = ["alloc"]
 
+# Required by the `rsa` crate in order to create PSS padding.
+# TODO: remove once `rsa` is updated
+[dependencies.digest-legacy]
+package = "digest"
+version = "0.9"
+default-features = false
+optional = true
+
 [dev-dependencies]
 assert_matches = "1.3"
 const-decoder = "0.2.0"
@@ -91,7 +99,7 @@ default = ["std", "clock", "serde_cbor"]
 # `secp256k1` crypto backend; `lazy_static` is required for internal initialization.
 es256k = ["secp256k1", "lazy_static"]
 # RSA algorithm and its dependencies (currently, `getrandom`-based RNG).
-with_rsa = ["rsa", "rand_core/getrandom"]
+with_rsa = ["rsa", "digest-legacy", "rand_core/getrandom"]
 # Enables `std`-specific functionality (such as error types implementing
 # the standard `Error` trait).
 std = ["anyhow/std"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ See the crate docs for the examples of usage.
   and thus be represented by different datatypes (e.g., `iss` may be a human-readable short ID,
   a hex-encoded key digest, etc.)
 
+## Supported Rust Versions
+
+The base crate is compatible with Rust 1.51+. The `k256` cryptographic backend requires Rust 1.56+,
+while other backends are compatible with 1.51+.
+
 ## Alternatives
 
 [`jsonwebtoken`], [`frank_jwt`] or [`biscuit`] may be viable alternatives depending on the use case

--- a/e2e-tests/no-std/Cargo.toml
+++ b/e2e-tests/no-std/Cargo.toml
@@ -38,7 +38,7 @@ lto = true
 # Crypto backends are included as features in order to not overflow
 # flash memory of the (emulated) microcontroller.
 [features]
-ed25519 = ["jwt-compact/ed25519-dalek"]
+ed25519 = ["getrandom", "once_cell", "rand_chacha", "jwt-compact/ed25519-compact"]
 with_rsa = ["getrandom", "once_cell", "rand_chacha", "rsa", "jwt-compact/with_rsa"]
 
 [workspace]

--- a/e2e-tests/no-std/src/main.rs
+++ b/e2e-tests/no-std/src/main.rs
@@ -29,7 +29,7 @@ use jwt_compact::{
 #[global_allocator]
 static ALLOCATOR: CortexMHeap = CortexMHeap::empty();
 
-#[cfg(feature = "with_rsa")]
+#[cfg(any(feature = "ed25519", feature = "with_rsa"))]
 mod rsa_helpers {
     use getrandom::{register_custom_getrandom, Error as RandomError};
     use once_cell::unsync::Lazy;
@@ -173,7 +173,7 @@ impl TokenChecker {
     }
 }
 
-const HEAP_SIZE: usize = 16_384;
+const HEAP_SIZE: usize = 32_768;
 
 const HASH_SECRET_KEY: &[u8] = b"super_secret_key_donut_steel";
 

--- a/src/alg.rs
+++ b/src/alg.rs
@@ -13,6 +13,8 @@ mod es256k;
 #[cfg(feature = "k256")]
 mod k256;
 // Alternative EdDSA implementations.
+#[cfg(any(feature = "digest-legacy", feature = "k256"))]
+mod digest_compat;
 #[cfg(feature = "ed25519-compact")]
 mod eddsa_compact;
 #[cfg(feature = "ed25519-dalek")]

--- a/src/alg/digest_compat.rs
+++ b/src/alg/digest_compat.rs
@@ -1,9 +1,10 @@
 //! Provides compatibility layer for using `digest 0.10` digests where `digest 0.9` traits
 //! are required. Motivated by `k256` and `rsa` crates depending on `digest 0.9`.
 
-use digest_legacy::{generic_array::GenericArray, BlockInput, FixedOutput, Reset, Update};
 #[cfg(feature = "k256")]
 use k256::ecdsa::digest as digest_legacy;
+
+use digest_legacy::{generic_array::GenericArray, BlockInput, FixedOutput, Reset, Update};
 use sha2::digest::{self, crypto_common::BlockSizeUser, Output};
 
 /// Thin wrapper around a `digest 0.10` hash digest. Implements traits from both 0.9 and 0.10.

--- a/src/alg/digest_compat.rs
+++ b/src/alg/digest_compat.rs
@@ -1,0 +1,73 @@
+//! Provides compatibility layer for using `digest 0.10` digests where `digest 0.9` traits
+//! are required. Motivated by `k256` and `rsa` crates depending on `digest 0.9`.
+
+use digest_legacy::{generic_array::GenericArray, BlockInput, FixedOutput, Reset, Update};
+#[cfg(feature = "k256")]
+use k256::ecdsa::digest as digest_legacy;
+use sha2::digest::{self, crypto_common::BlockSizeUser, Output};
+
+/// Thin wrapper around a `digest 0.10` hash digest. Implements traits from both 0.9 and 0.10.
+#[derive(Debug, Clone, Copy, Default)]
+#[repr(transparent)]
+pub(crate) struct Compat<T>(T);
+
+impl<T: digest::Update> Update for Compat<T> {
+    fn update(&mut self, data: impl AsRef<[u8]>) {
+        <T as digest::Update>::update(&mut self.0, data.as_ref());
+    }
+}
+
+impl<T: digest::Update> digest::Update for Compat<T> {
+    fn update(&mut self, data: &[u8]) {
+        <T as digest::Update>::update(&mut self.0, data);
+    }
+}
+
+impl<T> FixedOutput for Compat<T>
+where
+    T: digest::FixedOutputReset,
+{
+    type OutputSize = <T as digest::OutputSizeUser>::OutputSize;
+
+    fn finalize_into(self, out: &mut GenericArray<u8, Self::OutputSize>) {
+        <T as digest::FixedOutput>::finalize_into(self.0, out);
+    }
+
+    fn finalize_into_reset(&mut self, out: &mut GenericArray<u8, Self::OutputSize>) {
+        <T as digest::FixedOutputReset>::finalize_into_reset(&mut self.0, out);
+    }
+}
+
+impl<T: digest::OutputSizeUser> digest::OutputSizeUser for Compat<T> {
+    type OutputSize = <T as digest::OutputSizeUser>::OutputSize;
+}
+
+impl<T: digest::FixedOutput> digest::FixedOutput for Compat<T> {
+    fn finalize_into(self, out: &mut Output<Self>) {
+        <T as digest::FixedOutput>::finalize_into(self.0, out);
+    }
+}
+
+impl<T: digest::Reset> digest::Reset for Compat<T> {
+    fn reset(&mut self) {
+        <T as digest::Reset>::reset(&mut self.0);
+    }
+}
+
+impl<T: digest::Reset> Reset for Compat<T> {
+    fn reset(&mut self) {
+        <T as digest::Reset>::reset(&mut self.0);
+    }
+}
+
+impl<T: digest::FixedOutputReset> digest::FixedOutputReset for Compat<T> {
+    fn finalize_into_reset(&mut self, out: &mut Output<Self>) {
+        <T as digest::FixedOutputReset>::finalize_into_reset(&mut self.0, out);
+    }
+}
+
+impl<T: digest::HashMarker> digest::HashMarker for Compat<T> {}
+
+impl<T: BlockSizeUser> BlockInput for Compat<T> {
+    type BlockSize = <T as BlockSizeUser>::BlockSize;
+}

--- a/src/alg/es256k.rs
+++ b/src/alg/es256k.rs
@@ -8,7 +8,7 @@ use secp256k1::{
     All, Message, PublicKey, Secp256k1, SecretKey, Signature,
 };
 use sha2::{
-    digest::{generic_array::typenum::U32, BlockInput, Digest, FixedOutput, Reset, Update},
+    digest::{generic_array::typenum::U32, Digest},
     Sha256,
 };
 
@@ -51,7 +51,7 @@ pub struct Es256k<D = Sha256> {
 
 impl<D> Default for Es256k<D>
 where
-    D: BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
+    D: Digest<OutputSize = U32>,
 {
     fn default() -> Self {
         Es256k {
@@ -63,7 +63,7 @@ where
 
 impl<D> Es256k<D>
 where
-    D: BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
+    D: Digest<OutputSize = U32>,
 {
     /// Creates a new algorithm instance.
     /// This is a (moderately) expensive operation, so if necessary, the algorithm should
@@ -79,7 +79,7 @@ where
 
 impl<D> Algorithm for Es256k<D>
 where
-    D: BlockInput + FixedOutput<OutputSize = U32> + Clone + Default + Reset + Update,
+    D: Digest<OutputSize = U32>,
 {
     type SigningKey = SecretKey;
     type VerifyingKey = PublicKey;
@@ -90,7 +90,7 @@ where
     }
 
     fn sign(&self, signing_key: &Self::SigningKey, message: &[u8]) -> Self::Signature {
-        let mut digest = D::default();
+        let mut digest = D::new();
         digest.update(message);
         let message = Message::from_slice(&digest.finalize())
             .expect("failed to convert message to the correct form");
@@ -104,7 +104,7 @@ where
         verifying_key: &Self::VerifyingKey,
         message: &[u8],
     ) -> bool {
-        let mut digest = D::default();
+        let mut digest = D::new();
         digest.update(message);
         let message = Message::from_slice(&digest.finalize())
             .expect("failed to convert message to the correct form");

--- a/src/alg/rsa.rs
+++ b/src/alg/rsa.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256, Sha384, Sha512};
 use core::{convert::TryFrom, fmt, str::FromStr};
 
 use crate::{
-    alg::{SecretBytes, StrongKey, WeakKeyError},
+    alg::{digest_compat::Compat, SecretBytes, StrongKey, WeakKeyError},
     alloc::{Box, Cow, String, ToOwned, Vec},
     jwk::{JsonWebKey, JwkError, KeyType, RsaPrimeFactor, RsaPrivateParts},
     Algorithm, AlgorithmSignature,
@@ -249,15 +249,18 @@ impl Rsa {
                 // The salt length needs to be set to the size of hash function output;
                 // see https://www.rfc-editor.org/rfc/rfc7518.html#section-3.5.
                 match self.hash_alg {
-                    HashAlg::Sha256 => {
-                        PaddingScheme::new_pss_with_salt::<Sha256, _>(rng, Sha256::output_size())
-                    }
-                    HashAlg::Sha384 => {
-                        PaddingScheme::new_pss_with_salt::<Sha384, _>(rng, Sha384::output_size())
-                    }
-                    HashAlg::Sha512 => {
-                        PaddingScheme::new_pss_with_salt::<Sha512, _>(rng, Sha512::output_size())
-                    }
+                    HashAlg::Sha256 => PaddingScheme::new_pss_with_salt::<Compat<Sha256>, _>(
+                        rng,
+                        Sha256::output_size(),
+                    ),
+                    HashAlg::Sha384 => PaddingScheme::new_pss_with_salt::<Compat<Sha384>, _>(
+                        rng,
+                        Sha384::output_size(),
+                    ),
+                    HashAlg::Sha512 => PaddingScheme::new_pss_with_salt::<Compat<Sha512>, _>(
+                        rng,
+                        Sha512::output_size(),
+                    ),
                 }
             }
         }

--- a/src/token.rs
+++ b/src/token.rs
@@ -189,7 +189,6 @@ impl<T> Token<T> {
 /// ```
 /// # use jwt_compact::{alg::{Hs256, Hs256Key, Hs256Signature}, prelude::*};
 /// # use chrono::Duration;
-/// # use hmac::crypto_mac::generic_array::{typenum, GenericArray};
 /// # use serde::{Deserialize, Serialize};
 /// #
 /// #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
Also creates a compatibility layer because of some crypto backends (temporarily?) relying on the old `digest` version.