### PR TITLE
Fix CI build

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ let claims = Claims::new(CustomClaims { subject: "alice".to_owned() })
     .set_duration_and_issuance(&time_options, Duration::hours(1))
     .set_not_before(Utc::now());
 let token_string = Hs256.token(header, &claims, &key)?;
-println!("token: {}", token_string);
+println!("token: {token_string}");
 
 // Parse the token.
 let token = UntrustedToken::new(&token_string)?;

--- a/e2e-tests/no-std/src/main.rs
+++ b/e2e-tests/no-std/src/main.rs
@@ -91,7 +91,7 @@ impl TokenChecker {
         Ok(&token
             .claims()
             .validate_expiration(&self.time_options)
-            .map_err(|e| anyhow!(e))?
+            .map_err(|err| anyhow!(err))?
             .custom)
     }
 
@@ -101,10 +101,10 @@ impl TokenChecker {
         token: &str,
         verifying_key: &T::VerifyingKey,
     ) -> anyhow::Result<SampleClaims> {
-        let token = UntrustedToken::new(token).map_err(|e| anyhow!(e))?;
+        let token = UntrustedToken::new(token).map_err(|err| anyhow!(err))?;
         let token = alg
             .validate_integrity::<SampleClaims>(&token, verifying_key)
-            .map_err(|e| anyhow!(e))?;
+            .map_err(|err| anyhow!(err))?;
         let claims = self.extract_claims(&token)?;
         Ok(claims.to_owned())
     }
@@ -120,7 +120,7 @@ impl TokenChecker {
 
         let token = alg
             .token(Header::default(), &claims, signing_key)
-            .map_err(|e| anyhow!(e))?;
+            .map_err(|err| anyhow!(err))?;
         Ok(token)
     }
 
@@ -138,11 +138,12 @@ impl TokenChecker {
             name: "John Doe".to_owned(),
             admin: false,
         };
-        let signing_key = <T::SigningKey>::from_slice(signing_key).map_err(|e| anyhow!(e))?;
+        let signing_key = <T::SigningKey>::from_slice(signing_key).map_err(|err| anyhow!(err))?;
         let token = self.create_token(&alg, claims.clone(), &signing_key)?;
-        hprintln!("Created token: {}", token).unwrap();
+        hprintln!("Created token: {token}").unwrap();
 
-        let verifying_key = <T::VerifyingKey>::from_slice(verifying_key).map_err(|e| anyhow!(e))?;
+        let verifying_key =
+            <T::VerifyingKey>::from_slice(verifying_key).map_err(|err| anyhow!(err))?;
         let recovered_claims = self.verify_token(&alg, &token, &verifying_key)?;
         hprintln!("Verified token").unwrap();
         assert_eq!(claims, recovered_claims);
@@ -161,9 +162,10 @@ impl TokenChecker {
             name: "John Doe".to_owned(),
             admin: false,
         };
-        let signing_key = RsaPrivateKey::from_pkcs1_der(private_key_der).map_err(|e| anyhow!(e))?;
+        let signing_key =
+            RsaPrivateKey::from_pkcs1_der(private_key_der).map_err(|err| anyhow!(err))?;
         let token = self.create_token(alg, claims.clone(), &signing_key)?;
-        hprintln!("Created token: {}", token).unwrap();
+        hprintln!("Created token: {token}").unwrap();
 
         let verifying_key = RsaPublicKey::from(signing_key);
         let recovered_claims = self.verify_token(alg, &token, &verifying_key)?;

--- a/src/alg/eddsa_compact.rs
+++ b/src/alg/eddsa_compact.rs
@@ -76,7 +76,7 @@ impl Algorithm for Ed25519 {
 
 impl VerifyingKey<Ed25519> for PublicKey {
     fn from_slice(raw: &[u8]) -> anyhow::Result<Self> {
-        Self::from_slice(raw).map_err(|e| anyhow::anyhow!(e))
+        Self::from_slice(raw).map_err(|err| anyhow::anyhow!(err))
     }
 
     fn as_bytes(&self) -> Cow<'_, [u8]> {
@@ -86,7 +86,7 @@ impl VerifyingKey<Ed25519> for PublicKey {
 
 impl SigningKey<Ed25519> for SecretKey {
     fn from_slice(raw: &[u8]) -> anyhow::Result<Self> {
-        Self::from_slice(raw).map_err(|e| anyhow::anyhow!(e))
+        Self::from_slice(raw).map_err(|err| anyhow::anyhow!(err))
     }
 
     fn to_verifying_key(&self) -> PublicKey {

--- a/src/alg/eddsa_dalek.rs
+++ b/src/alg/eddsa_dalek.rs
@@ -18,7 +18,7 @@ impl AlgorithmSignature for Signature {
     const LENGTH: Option<NonZeroUsize> = NonZeroUsize::new(SIGNATURE_LENGTH);
 
     fn try_from_slice(bytes: &[u8]) -> anyhow::Result<Self> {
-        Self::try_from(bytes).map_err(|e| anyhow::anyhow!(e))
+        Self::try_from(bytes).map_err(|err| anyhow::anyhow!(err))
     }
 
     fn as_bytes(&self) -> Cow<'_, [u8]> {
@@ -68,7 +68,7 @@ impl Algorithm for Ed25519 {
 
 impl VerifyingKey<Ed25519> for PublicKey {
     fn from_slice(raw: &[u8]) -> anyhow::Result<Self> {
-        Self::from_bytes(raw).map_err(|e| anyhow::anyhow!(e))
+        Self::from_bytes(raw).map_err(|err| anyhow::anyhow!(err))
     }
 
     fn as_bytes(&self) -> Cow<'_, [u8]> {
@@ -78,7 +78,7 @@ impl VerifyingKey<Ed25519> for PublicKey {
 
 impl SigningKey<Ed25519> for Keypair {
     fn from_slice(raw: &[u8]) -> anyhow::Result<Self> {
-        Self::from_bytes(raw).map_err(|e| anyhow::anyhow!(e))
+        Self::from_bytes(raw).map_err(|err| anyhow::anyhow!(err))
     }
 
     fn to_verifying_key(&self) -> PublicKey {

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,11 +29,11 @@ pub enum ParseError {
 impl fmt::Display for ParseError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InvalidTokenStructure => formatter.write_str("Invalid token structure"),
+            Self::InvalidTokenStructure => formatter.write_str("invalid token structure"),
             Self::InvalidBase64Encoding => write!(formatter, "invalid base64 decoding"),
-            Self::MalformedHeader(e) => write!(formatter, "Malformed token header: {}", e),
+            Self::MalformedHeader(err) => write!(formatter, "malformed token header: {err}"),
             Self::UnsupportedContentType(ty) => {
-                write!(formatter, "Unsupported content type: {}", ty)
+                write!(formatter, "unsupported content type: {ty}")
             }
         }
     }
@@ -43,7 +43,7 @@ impl fmt::Display for ParseError {
 impl std::error::Error for ParseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::MalformedHeader(e) => Some(e),
+            Self::MalformedHeader(err) => Some(err),
             _ => None,
         }
     }
@@ -109,28 +109,25 @@ impl fmt::Display for ValidationError {
         match self {
             Self::AlgorithmMismatch { expected, actual } => write!(
                 formatter,
-                "Token algorithm ({actual}) differs from expected ({expected})",
+                "token algorithm ({actual}) differs from expected ({expected})",
                 expected = expected,
                 actual = actual
             ),
             Self::InvalidSignatureLen { expected, actual } => write!(
                 formatter,
-                "Invalid signature length: expected {expected} bytes, got {actual} bytes",
-                expected = expected,
-                actual = actual
+                "invalid signature length: expected {expected} bytes, got {actual} bytes"
             ),
-            Self::MalformedSignature(e) => write!(formatter, "Malformed token signature: {}", e),
-            Self::InvalidSignature => formatter.write_str("Signature has failed verification"),
-            Self::MalformedClaims(e) => write!(formatter, "Cannot deserialize claims: {}", e),
+            Self::MalformedSignature(err) => write!(formatter, "malformed token signature: {err}"),
+            Self::InvalidSignature => formatter.write_str("signature has failed verification"),
+            Self::MalformedClaims(err) => write!(formatter, "cannot deserialize claims: {err}"),
             #[cfg(feature = "serde_cbor")]
-            Self::MalformedCborClaims(e) => write!(formatter, "Cannot deserialize claims: {}", e),
+            Self::MalformedCborClaims(err) => write!(formatter, "cannot deserialize claims: {err}"),
             Self::NoClaim(claim) => write!(
                 formatter,
-                "Claim `{}` requested during validation is not present in the token",
-                claim
+                "claim `{claim}` requested during validation is not present in the token"
             ),
-            Self::Expired => formatter.write_str("Token has expired"),
-            Self::NotMature => formatter.write_str("Token is not yet ready"),
+            Self::Expired => formatter.write_str("token has expired"),
+            Self::NotMature => formatter.write_str("token is not yet ready"),
         }
     }
 }
@@ -139,10 +136,10 @@ impl fmt::Display for ValidationError {
 impl std::error::Error for ValidationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::MalformedSignature(e) => Some(e.as_ref()),
-            Self::MalformedClaims(e) => Some(e),
+            Self::MalformedSignature(err) => Some(err.as_ref()),
+            Self::MalformedClaims(err) => Some(err),
             #[cfg(feature = "serde_cbor")]
-            Self::MalformedCborClaims(e) => Some(e),
+            Self::MalformedCborClaims(err) => Some(err),
             _ => None,
         }
     }
@@ -165,10 +162,10 @@ pub enum CreationError {
 impl fmt::Display for CreationError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Header(e) => write!(formatter, "Cannot serialize header: {}", e),
-            Self::Claims(e) => write!(formatter, "Cannot serialize claims: {}", e),
+            Self::Header(err) => write!(formatter, "cannot serialize header: {err}"),
+            Self::Claims(err) => write!(formatter, "cannot serialize claims: {err}"),
             #[cfg(feature = "serde_cbor")]
-            Self::CborClaims(e) => write!(formatter, "Cannot serialize claims into CBOR: {}", e),
+            Self::CborClaims(err) => write!(formatter, "cannot serialize claims into CBOR: {err}"),
         }
     }
 }
@@ -177,9 +174,9 @@ impl fmt::Display for CreationError {
 impl std::error::Error for CreationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::Header(e) | Self::Claims(e) => Some(e),
+            Self::Header(err) | Self::Claims(err) => Some(err),
             #[cfg(feature = "serde_cbor")]
-            Self::CborClaims(e) => Some(e),
+            Self::CborClaims(err) => Some(err),
         }
     }
 }

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -113,11 +113,10 @@ impl fmt::Display for JwkError {
             Self::UnexpectedKeyType { expected, actual } => {
                 write!(
                     formatter,
-                    "unexpected key type: {} (expected {})",
-                    actual, expected
+                    "unexpected key type: {actual} (expected {expected})"
                 )
             }
-            Self::NoField(field) => write!(formatter, "field `{}` is absent from JWK", field),
+            Self::NoField(field) => write!(formatter, "field `{field}` is absent from JWK"),
             Self::UnexpectedValue {
                 field,
                 expected,
@@ -125,8 +124,7 @@ impl fmt::Display for JwkError {
             } => {
                 write!(
                     formatter,
-                    "field `{}` has unexpected value (expected: {}, got: {})",
-                    field, expected, actual
+                    "field `{field}` has unexpected value (expected: {expected}, got: {actual})"
                 )
             }
             Self::UnexpectedLen {
@@ -136,8 +134,7 @@ impl fmt::Display for JwkError {
             } => {
                 write!(
                     formatter,
-                    "field `{}` has unexpected length (expected: {}, got: {})",
-                    field, expected, actual
+                    "field `{field}` has unexpected length (expected: {expected}, got: {actual})"
                 )
             }
             Self::MismatchedKeys => {
@@ -358,7 +355,7 @@ impl fmt::Display for JsonWebKey<'_> {
         formatter.write_str("{")?;
         let field_count = json_entries.len();
         for (i, (name, value)) in json_entries.into_iter().enumerate() {
-            write!(formatter, "\"{name}\":{value}", name = name, value = value)?;
+            write!(formatter, "\"{name}\":{value}")?;
             if i + 1 < field_count {
                 formatter.write_str(",")?;
             }
@@ -590,8 +587,7 @@ mod tests {
             .to_string();
         assert!(
             missing_field_err.contains("missing field `kty`"),
-            "{}",
-            missing_field_err
+            "{missing_field_err}"
         );
 
         let base64_json = r#"{"crv":"Ed25519","kty":"OKP","x":"??"}"#;
@@ -600,13 +596,11 @@ mod tests {
             .to_string();
         assert!(
             base64_err.contains("invalid value: string \"??\""),
-            "{}",
-            base64_err
+            "{base64_err}"
         );
         assert!(
             base64_err.contains("base64url-encoded data"),
-            "{}",
-            base64_err
+            "{base64_err}"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@
 //!     .set_duration_and_issuance(&time_options, Duration::days(7))
 //!     .set_not_before(Utc::now() - Duration::hours(1));
 //! let token_string = Hs256.token(header, &claims, &key)?;
-//! println!("token: {}", token_string);
+//! println!("token: {token_string}");
 //!
 //! // Parse the token.
 //! let token = UntrustedToken::new(&token_string)?;
@@ -171,9 +171,9 @@
 //! let claims = Claims::new(CustomClaims { subject: [111; 32] })
 //!     .set_duration_and_issuance(&time_options, Duration::days(7));
 //! let token = Hs256.token(Header::default(), &claims, &key)?;
-//! println!("token: {}", token);
+//! println!("token: {token}");
 //! let compact_token = Hs256.compact_token(Header::default(), &claims, &key)?;
-//! println!("compact token: {}", compact_token);
+//! println!("compact token: {compact_token}");
 //! // The compact token should be ~40 chars shorter.
 //!
 //! // Parse the compact token.

--- a/src/token.rs
+++ b/src/token.rs
@@ -591,7 +591,7 @@ mod tests {
         let claims_start = HS256_TOKEN.find('.').unwrap() + 1;
         let claims_end = HS256_TOKEN.rfind('.').unwrap();
         let key = Base64UrlUnpadded::decode_vec(HS256_KEY).unwrap();
-        let key = Hs256Key::new(&key);
+        let key = Hs256Key::new(key);
 
         for claims in &malformed_claims {
             let encoded_claims = Base64UrlUnpadded::encode_string(claims.as_bytes());
@@ -601,8 +601,7 @@ mod tests {
             assert_matches!(
                 Hs256.validate_integrity::<Obj>(&token, &key).unwrap_err(),
                 ValidationError::MalformedClaims(_),
-                "Failing claims: {}",
-                claims
+                "Failing claims: {claims}"
             );
         }
     }
@@ -610,7 +609,7 @@ mod tests {
     fn test_invalid_signature_len(mangled_str: &str, actual_len: usize) {
         let token = UntrustedToken::new(&mangled_str).unwrap();
         let key = Base64UrlUnpadded::decode_vec(HS256_KEY).unwrap();
-        let key = Hs256Key::new(&key);
+        let key = Hs256Key::new(key);
 
         let err = Hs256.validate_integrity::<Empty>(&token, &key).unwrap_err();
         assert_matches!(

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -39,7 +39,7 @@ fn hs256_reference() {
     assert_eq!(token.algorithm(), "HS256");
 
     let key = Base64UrlUnpadded::decode_vec(KEY).unwrap();
-    let key = Hs256Key::new(&key);
+    let key = Hs256Key::new(key);
     let validated_token = Hs256.validate_integrity::<Obj>(&token, &key).unwrap();
     assert_eq!(
         validated_token.claims().expiration.unwrap().timestamp(),
@@ -313,7 +313,7 @@ fn test_algorithm<A: Algorithm>(
             .unwrap_err();
         match err {
             ValidationError::InvalidSignature | ValidationError::MalformedSignature(_) => {}
-            err => panic!("Unexpected error: {:?}", err),
+            err => panic!("Unexpected error: {err:?}"),
         }
     }
 

--- a/tests/jwk.rs
+++ b/tests/jwk.rs
@@ -42,7 +42,7 @@ fn hs256_jwk() {
         "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow";
 
     let key = Base64UrlUnpadded::decode_vec(KEY).unwrap();
-    let key = Hs256Key::new(&key);
+    let key = Hs256Key::new(key);
 
     let jwk = JsonWebKey::from(&key);
     assert_eq!(
@@ -385,8 +385,8 @@ mod es256k {
 
         assert_matches!(
             err,
-            JwkError::Custom(e) if e.to_string().contains("malformed public key") ||
-                e.to_string().contains("signature error")
+            JwkError::Custom(err) if err.to_string().contains("malformed public key") ||
+                err.to_string().contains("signature error")
         );
     }
 
@@ -577,8 +577,8 @@ mod es256 {
 
         assert_matches!(
             err,
-            JwkError::Custom(e) if e.to_string().contains("malformed public key") ||
-                e.to_string().contains("signature error")
+            JwkError::Custom(err) if err.to_string().contains("malformed public key") ||
+                err.to_string().contains("signature error")
         );
     }
 


### PR DESCRIPTION
Fixes [the latest build failure](https://github.com/slowli/jwt-compact/actions/runs/3743242289/jobs/6355202294) caused by new clippy lints, such as inlining local variables into `format!` strings.