### PR TITLE
Make `Header` generic to allow custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 ### Changed
 
 - Update `secp256k1` and `rsa` dependencies.
+- Make JWT `Header` generic similar to `Claims`, so that it contain custom fields
+  as per [Section 4.2 of RFC 7515](https://www.rfc-editor.org/rfc/rfc7515#section-4.2).
+  Since `Default` is now implemented for all `Header<T: Default>`, one should use
+  a new `Header::empty()` method to create an empty header, and `Header::new()` to create
+  a header with custom fields.
+- Take `Header<_>` by reference in `AlgorithmExt` methods creating tokens (previously,
+  it was taken by value).
+
+### Deprecated
+
+- Deprecate `validate_integrity` and `validate_for_signed_token` methods in `AlgorithmExt`.
+  An extended version of this functionality, which can validate tokens with custom headers,
+  is now encapsulated in the new `Validator` type, which is returned
+  by the new `AlgorithmExt::validator()` method.
 
 ## 0.7.0 - 2023-03-14
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ let header = Header::empty().with_key_id("my-key");
 let claims = Claims::new(CustomClaims { subject: "alice".to_owned() })
     .set_duration_and_issuance(&time_options, Duration::hours(1))
     .set_not_before(Utc::now());
-let token_string = Hs256.token(header, &claims, &key)?;
+let token_string = Hs256.token(&header, &claims, &key)?;
 println!("token: {token_string}");
 
 // Parse the token.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ let time_options = TimeOptions::default();
 // Create a symmetric HMAC key, which will be used both to create and verify tokens.
 let key = Hs256Key::new(b"super_secret_key_donut_steel");
 // Create a token.
-let header = Header::default().with_key_id("my-key");
+let header = Header::empty().with_key_id("my-key");
 let claims = Claims::new(CustomClaims { subject: "alice".to_owned() })
     .set_duration_and_issuance(&time_options, Duration::hours(1))
     .set_not_before(Utc::now());
@@ -53,7 +53,7 @@ let token = UntrustedToken::new(&token_string)?;
 // using the `Header.key_id` field.
 assert_eq!(token.header().key_id.as_deref(), Some("my-key"));
 // Validate the token integrity.
-let token: Token<CustomClaims> = Hs256.validate_integrity(&token, &key)?;
+let token: Token<CustomClaims> = Hs256.validator(&key).validate(&token)?;
 // Validate additional conditions.
 token.claims()
     .validate_expiration(&time_options)?

--- a/benches/encoding.rs
+++ b/benches/encoding.rs
@@ -53,7 +53,7 @@ fn encoding_benches(criterion: &mut Criterion) {
 
     criterion.bench_function("encoding/full", |bencher| {
         bencher.iter(|| {
-            let header = Header::default().with_key_id(&key_id);
+            let header = Header::empty().with_key_id(&key_id);
             let claims = Claims::new(&claims)
                 .set_duration_and_issuance(&time_options, Duration::minutes(10))
                 .set_not_before(Utc::now() - Duration::minutes(10));
@@ -64,7 +64,7 @@ fn encoding_benches(criterion: &mut Criterion) {
     #[cfg(feature = "serde_cbor")]
     criterion.bench_function("encoding_cbor/full", |bencher| {
         bencher.iter(|| {
-            let header = Header::default().with_key_id(&key_id);
+            let header = Header::empty().with_key_id(&key_id);
             let claims = Claims::new(&claims)
                 .set_duration_and_issuance(&time_options, Duration::minutes(10))
                 .set_not_before(Utc::now() - Duration::minutes(10));
@@ -75,7 +75,7 @@ fn encoding_benches(criterion: &mut Criterion) {
 
 fn decoding_benches(criterion: &mut Criterion) {
     let key = Hs256Key::new(b"super_secret_key_donut_steel");
-    let header = Header::default().with_key_id(Uuid::new_v4().to_string());
+    let header = Header::empty().with_key_id(Uuid::new_v4().to_string());
     let time_options = TimeOptions::default();
     let claims = Claims::new(CustomClaims::default())
         .set_duration_and_issuance(&time_options, Duration::minutes(10))
@@ -91,7 +91,8 @@ fn decoding_benches(criterion: &mut Criterion) {
             bencher.iter(|| {
                 let token = UntrustedToken::new(&compact_token).unwrap();
                 Hs256
-                    .validate_integrity::<CustomClaims>(&token, &key)
+                    .validator::<CustomClaims>(&key)
+                    .validate(&token)
                     .unwrap()
             });
         });
@@ -105,7 +106,8 @@ fn decoding_benches(criterion: &mut Criterion) {
         bencher.iter(|| {
             let token = UntrustedToken::new(&token).unwrap();
             Hs256
-                .validate_integrity::<CustomClaims>(&token, &key)
+                .validator::<CustomClaims>(&key)
+                .validate(&token)
                 .unwrap()
         });
     });

--- a/benches/encoding.rs
+++ b/benches/encoding.rs
@@ -57,7 +57,7 @@ fn encoding_benches(criterion: &mut Criterion) {
             let claims = Claims::new(&claims)
                 .set_duration_and_issuance(&time_options, Duration::minutes(10))
                 .set_not_before(Utc::now() - Duration::minutes(10));
-            Hs256.token(header, &claims, &key).unwrap()
+            Hs256.token(&header, &claims, &key).unwrap()
         });
     });
 
@@ -68,7 +68,7 @@ fn encoding_benches(criterion: &mut Criterion) {
             let claims = Claims::new(&claims)
                 .set_duration_and_issuance(&time_options, Duration::minutes(10))
                 .set_not_before(Utc::now() - Duration::minutes(10));
-            Hs256.compact_token(header, &claims, &key).unwrap()
+            Hs256.compact_token(&header, &claims, &key).unwrap()
         });
     });
 }
@@ -83,7 +83,7 @@ fn decoding_benches(criterion: &mut Criterion) {
 
     #[cfg(feature = "serde_cbor")]
     {
-        let compact_token = Hs256.compact_token(header.clone(), &claims, &key).unwrap();
+        let compact_token = Hs256.compact_token(&header, &claims, &key).unwrap();
         criterion.bench_function("decoding_cbor", |bencher| {
             bencher.iter(|| UntrustedToken::new(&compact_token).unwrap())
         });
@@ -98,7 +98,7 @@ fn decoding_benches(criterion: &mut Criterion) {
         });
     }
 
-    let token = Hs256.token(header, &claims, &key).unwrap();
+    let token = Hs256.token(&header, &claims, &key).unwrap();
     criterion.bench_function("decoding", |bencher| {
         bencher.iter(|| UntrustedToken::new(&token).unwrap())
     });

--- a/e2e-tests/no-std/src/main.rs
+++ b/e2e-tests/no-std/src/main.rs
@@ -102,7 +102,8 @@ impl TokenChecker {
     ) -> anyhow::Result<SampleClaims> {
         let token = UntrustedToken::new(token).map_err(|err| anyhow!(err))?;
         let token = alg
-            .validate_integrity::<SampleClaims>(&token, verifying_key)
+            .validator::<SampleClaims>(verifying_key)
+            .validate(&token)
             .map_err(|err| anyhow!(err))?;
         let claims = self.extract_claims(&token)?;
         Ok(claims.to_owned())
@@ -118,7 +119,7 @@ impl TokenChecker {
             .set_duration_and_issuance(&self.time_options, Duration::minutes(10));
 
         let token = alg
-            .token(Header::default(), &claims, signing_key)
+            .token(Header::empty(), &claims, signing_key)
             .map_err(|err| anyhow!(err))?;
         Ok(token)
     }

--- a/e2e-tests/no-std/src/main.rs
+++ b/e2e-tests/no-std/src/main.rs
@@ -119,7 +119,7 @@ impl TokenChecker {
             .set_duration_and_issuance(&self.time_options, Duration::minutes(10));
 
         let token = alg
-            .token(Header::empty(), &claims, signing_key)
+            .token(&Header::empty(), &claims, signing_key)
             .map_err(|err| anyhow!(err))?;
         Ok(token)
     }

--- a/e2e-tests/wasm/src/lib.rs
+++ b/e2e-tests/wasm/src/lib.rs
@@ -94,7 +94,7 @@ where
     let claims = Claims::new(claims).set_duration(&TimeOptions::default(), Duration::hours(1));
 
     let token = alg
-        .token(Header::empty(), &claims, &secret_key)
+        .token(&Header::empty(), &claims, &secret_key)
         .map_err(to_js_error)?;
     Ok(token)
 }

--- a/e2e-tests/wasm/src/lib.rs
+++ b/e2e-tests/wasm/src/lib.rs
@@ -78,7 +78,8 @@ where
     let verifying_key = <T::VerifyingKey>::try_from(jwk).map_err(to_js_error)?;
 
     let token = alg
-        .validate_integrity::<SampleClaims>(token, &verifying_key)
+        .validator::<SampleClaims>(&verifying_key)
+        .validate(token)
         .map_err(to_js_error)?;
     let claims = extract_claims(&token)?;
     Ok(from_serde(claims).expect("Cannot serialize claims"))
@@ -93,7 +94,7 @@ where
     let claims = Claims::new(claims).set_duration(&TimeOptions::default(), Duration::hours(1));
 
     let token = alg
-        .token(Header::default(), &claims, &secret_key)
+        .token(Header::empty(), &claims, &secret_key)
         .map_err(to_js_error)?;
     Ok(token)
 }

--- a/src/alg.rs
+++ b/src/alg.rs
@@ -115,7 +115,7 @@ impl<T: fmt::Debug + 'static> std::error::Error for WeakKeyError<T> {}
 /// let claims = // ...
 /// #   Claims::empty();
 /// let token = StrongAlg(Hs256)
-///     .token(Header::default(), &claims, &strong_key)?;
+///     .token(Header::empty(), &claims, &strong_key)?;
 /// # Ok(())
 /// # }
 /// ```

--- a/src/alg.rs
+++ b/src/alg.rs
@@ -115,7 +115,7 @@ impl<T: fmt::Debug + 'static> std::error::Error for WeakKeyError<T> {}
 /// let claims = // ...
 /// #   Claims::empty();
 /// let token = StrongAlg(Hs256)
-///     .token(Header::empty(), &claims, &strong_key)?;
+///     .token(&Header::empty(), &claims, &strong_key)?;
 /// # Ok(())
 /// # }
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,7 @@ pub use crate::{
     claims::{Claims, Empty, TimeOptions},
     error::{Claim, CreationError, ParseError, ValidationError},
     token::{Header, SignedToken, Token, UntrustedToken},
-    traits::{Algorithm, AlgorithmExt, AlgorithmSignature, Renamed},
+    traits::{Algorithm, AlgorithmExt, AlgorithmSignature, Renamed, Validator},
 };
 
 #[cfg(doctest)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@
 //! // Create a symmetric HMAC key, which will be used both to create and verify tokens.
 //! let key = Hs256Key::new(b"super_secret_key_donut_steel");
 //! // Create a token.
-//! let header = Header::default().with_key_id("my-key");
+//! let header = Header::empty().with_key_id("my-key");
 //! let claims = Claims::new(CustomClaims { subject: "alice".to_owned() })
 //!     .set_duration_and_issuance(&time_options, Duration::days(7))
 //!     .set_not_before(Utc::now() - Duration::hours(1));
@@ -135,7 +135,7 @@
 //! // using the `Header.key_id` field.
 //! assert_eq!(token.header().key_id, Some("my-key".to_owned()));
 //! // Validate the token integrity.
-//! let token: Token<CustomClaims> = Hs256.validate_integrity(&token, &key)?;
+//! let token: Token<CustomClaims> = Hs256.validator(&key).validate(&token)?;
 //! // Validate additional conditions.
 //! token.claims()
 //!     .validate_expiration(&time_options)?
@@ -170,15 +170,15 @@
 //! let key = Hs256Key::new(b"super_secret_key_donut_steel");
 //! let claims = Claims::new(CustomClaims { subject: [111; 32] })
 //!     .set_duration_and_issuance(&time_options, Duration::days(7));
-//! let token = Hs256.token(Header::default(), &claims, &key)?;
+//! let token = Hs256.token(Header::empty(), &claims, &key)?;
 //! println!("token: {token}");
-//! let compact_token = Hs256.compact_token(Header::default(), &claims, &key)?;
+//! let compact_token = Hs256.compact_token(Header::empty(), &claims, &key)?;
 //! println!("compact token: {compact_token}");
 //! // The compact token should be ~40 chars shorter.
 //!
 //! // Parse the compact token.
 //! let token = UntrustedToken::new(&compact_token)?;
-//! let token: Token<CustomClaims> = Hs256.validate_integrity(&token, &key)?;
+//! let token: Token<CustomClaims> = Hs256.validator(&key).validate(&token)?;
 //! token.claims().validate_expiration(&time_options)?;
 //! // Now, we can extract information from the token (e.g., its subject).
 //! assert_eq!(token.claims().custom.subject, [111; 32]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@
 //! let claims = Claims::new(CustomClaims { subject: "alice".to_owned() })
 //!     .set_duration_and_issuance(&time_options, Duration::days(7))
 //!     .set_not_before(Utc::now() - Duration::hours(1));
-//! let token_string = Hs256.token(header, &claims, &key)?;
+//! let token_string = Hs256.token(&header, &claims, &key)?;
 //! println!("token: {token_string}");
 //!
 //! // Parse the token.
@@ -170,9 +170,9 @@
 //! let key = Hs256Key::new(b"super_secret_key_donut_steel");
 //! let claims = Claims::new(CustomClaims { subject: [111; 32] })
 //!     .set_duration_and_issuance(&time_options, Duration::days(7));
-//! let token = Hs256.token(Header::empty(), &claims, &key)?;
+//! let token = Hs256.token(&Header::empty(), &claims, &key)?;
 //! println!("token: {token}");
-//! let compact_token = Hs256.compact_token(Header::empty(), &claims, &key)?;
+//! let compact_token = Hs256.compact_token(&Header::empty(), &claims, &key)?;
 //! println!("compact token: {compact_token}");
 //! // The compact token should be ~40 chars shorter.
 //!

--- a/src/token.rs
+++ b/src/token.rs
@@ -183,7 +183,7 @@ pub(crate) struct CompleteHeader<'a, T> {
     #[serde(rename = "cty", default, skip_serializing_if = "Option::is_none")]
     pub content_type: Option<String>,
     #[serde(flatten)]
-    pub inner: Header<T>,
+    pub inner: T,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -254,7 +254,7 @@ impl<T, H> Token<T, H> {
 /// # let claims = Claims::new(MyClaims {})
 /// #     .set_duration_and_issuance(&TimeOptions::default(), Duration::days(7));
 /// let token_string: String = // token from an external source
-/// #   Hs256.token(Header::empty(), &claims, &key)?;
+/// #   Hs256.token(&Header::empty(), &claims, &key)?;
 /// let token = UntrustedToken::new(&token_string)?;
 /// let signed = Hs256.validator::<MyClaims>(&key)
 ///     .validate_for_signed_token(&token)?;
@@ -545,7 +545,7 @@ mod tests {
     #[test]
     fn header_with_x5t_field() {
         let header = r#"{"alg":"HS256","x5t":"lDpwLQbzRZmu4fjajvn3KWAx1pk"}"#;
-        let header: CompleteHeader<Empty> = serde_json::from_str(header).unwrap();
+        let header: CompleteHeader<Header<Empty>> = serde_json::from_str(header).unwrap();
         let thumbprint = header.inner.certificate_sha1_thumbprint.unwrap();
 
         assert_eq!(thumbprint[0], 0x94);
@@ -564,7 +564,7 @@ mod tests {
     #[test]
     fn header_with_x5t_sha256_field() {
         let header = r#"{"alg":"HS256","x5t#S256":"MV9b23bQeMQ7isAGTkoBZGErH853yGk0W_yUx1iU7dM"}"#;
-        let header: CompleteHeader<Empty> = serde_json::from_str(header).unwrap();
+        let header: CompleteHeader<Header<Empty>> = serde_json::from_str(header).unwrap();
         let thumbprint = header.inner.certificate_thumbprint.unwrap();
 
         assert_eq!(thumbprint[0], 0x31);
@@ -629,7 +629,7 @@ mod tests {
     #[test]
     fn extracting_custom_header_fields() {
         let header = r#"{"alg":"HS256","custom":[1,"field"],"x5t":"lDpwLQbzRZmu4fjajvn3KWAx1pk"}"#;
-        let header: CompleteHeader<Obj> = serde_json::from_str(header).unwrap();
+        let header: CompleteHeader<Header<Obj>> = serde_json::from_str(header).unwrap();
         assert_eq!(header.algorithm, "HS256");
         assert!(header.inner.certificate_sha1_thumbprint.is_some());
         assert_eq!(header.inner.other_fields.len(), 1);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -72,7 +72,7 @@ pub trait Algorithm {
 /// # fn main() -> anyhow::Result<()> {
 /// let alg = Renamed::new(Hs256, "HS2");
 /// let key = Hs256Key::new(b"super_secret_key_donut_steel");
-/// let token_string = alg.token(Header::empty(), &Claims::empty(), &key)?;
+/// let token_string = alg.token(&Header::empty(), &Claims::empty(), &key)?;
 ///
 /// let token = UntrustedToken::new(&token_string)?;
 /// assert_eq!(token.algorithm(), "HS2");
@@ -130,7 +130,7 @@ pub trait AlgorithmExt: Algorithm {
     /// Creates a new token and serializes it to string.
     fn token<T>(
         &self,
-        header: Header<impl Serialize>,
+        header: &Header<impl Serialize>,
         claims: &Claims<T>,
         signing_key: &Self::SigningKey,
     ) -> Result<String, CreationError>
@@ -142,7 +142,7 @@ pub trait AlgorithmExt: Algorithm {
     #[cfg_attr(docsrs, doc(cfg(feature = "serde_cbor")))]
     fn compact_token<T>(
         &self,
-        header: Header<impl Serialize>,
+        header: &Header<impl Serialize>,
         claims: &Claims<T>,
         signing_key: &Self::SigningKey,
     ) -> Result<String, CreationError>
@@ -180,7 +180,7 @@ pub trait AlgorithmExt: Algorithm {
 impl<A: Algorithm> AlgorithmExt for A {
     fn token<T>(
         &self,
-        header: Header<impl Serialize>,
+        header: &Header<impl Serialize>,
         claims: &Claims<T>,
         signing_key: &Self::SigningKey,
     ) -> Result<String, CreationError>
@@ -211,7 +211,7 @@ impl<A: Algorithm> AlgorithmExt for A {
     #[cfg(feature = "serde_cbor")]
     fn compact_token<T>(
         &self,
-        header: Header<impl Serialize>,
+        header: &Header<impl Serialize>,
         claims: &Claims<T>,
         signing_key: &Self::SigningKey,
     ) -> Result<String, CreationError>

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -72,16 +72,16 @@ pub trait Algorithm {
 /// # fn main() -> anyhow::Result<()> {
 /// let alg = Renamed::new(Hs256, "HS2");
 /// let key = Hs256Key::new(b"super_secret_key_donut_steel");
-/// let token_string = alg.token(Header::default(), &Claims::empty(), &key)?;
+/// let token_string = alg.token(Header::empty(), &Claims::empty(), &key)?;
 ///
 /// let token = UntrustedToken::new(&token_string)?;
 /// assert_eq!(token.algorithm(), "HS2");
 /// // Note that the created token cannot be verified against the original algorithm
 /// // since the algorithm name recorded in the token header doesn't match.
-/// assert!(Hs256.validate_integrity::<Empty>(&token, &key).is_err());
+/// assert!(Hs256.validator::<Empty>(&key).validate(&token).is_err());
 ///
 /// // ...but the modified alg is working as expected.
-/// assert!(alg.validate_integrity::<Empty>(&token, &key).is_ok());
+/// assert!(alg.validator::<Empty>(&key).validate(&token).is_ok());
 /// # Ok(())
 /// # }
 /// ```
@@ -150,7 +150,7 @@ pub trait AlgorithmExt: Algorithm {
         T: Serialize;
 
     /// Creates a JWT validator for the specified verifying key and the claims type.
-    /// The validator can then be used to validate one or more tokens.
+    /// The validator can then be used to validate integrity of one or more tokens.
     fn validator<'a, T>(&'a self, verifying_key: &'a Self::VerifyingKey) -> Validator<'a, Self, T>;
 
     /// Validates the token integrity against the provided `verifying_key`.

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -285,8 +285,10 @@ fn hs512_algorithm() {
 fn compact_token_hs256() {
     let claims = shared::create_claims();
     let key = Hs256Key::generate(&mut thread_rng()).into_inner();
-    let long_token_str = Hs256.token(Header::empty(), &claims, &key).unwrap();
-    let token_str = Hs256.compact_token(Header::empty(), &claims, &key).unwrap();
+    let long_token_str = Hs256.token(&Header::empty(), &claims, &key).unwrap();
+    let token_str = Hs256
+        .compact_token(&Header::empty(), &claims, &key)
+        .unwrap();
     assert!(
         token_str.len() < long_token_str.len() - 40,
         "Full token length = {}, compact token length = {}",
@@ -464,7 +466,7 @@ fn test_algorithm_with_custom_header<A: Algorithm>(
     #[cfg(feature = "serde_cbor")]
     {
         let token_string = algorithm
-            .compact_token(header.clone(), &claims, signing_key)
+            .compact_token(&header, &claims, signing_key)
             .unwrap();
         let token = Untrusted::try_from(token_string.as_str()).unwrap();
         assert_eq!(token.header().other_fields.custom, "custom");
@@ -474,7 +476,7 @@ fn test_algorithm_with_custom_header<A: Algorithm>(
     }
 
     // Successful case.
-    let token_string = algorithm.token(header, &claims, signing_key).unwrap();
+    let token_string = algorithm.token(&header, &claims, signing_key).unwrap();
     let token = Untrusted::try_from(token_string.as_str()).unwrap();
     assert_eq!(token.header().other_fields.custom, "custom");
     let token = algorithm.validator(verifying_key).validate(&token).unwrap();
@@ -500,7 +502,7 @@ fn test_algorithm_with_custom_header<A: Algorithm>(
 
     // Check that token validation fails if the mandatory field is missing from the header.
     let bogus_token_string = algorithm
-        .token(Header::empty(), &claims, signing_key)
+        .token(&Header::empty(), &claims, signing_key)
         .unwrap();
     let err = Untrusted::try_from(bogus_token_string.as_str()).unwrap_err();
     let ParseError::MalformedHeader(err) = err else {

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -444,12 +444,11 @@ struct HeaderExtensions {
 }
 
 fn create_header() -> Header<HeaderExtensions> {
-    Header::empty()
-        .with_token_type("JWT")
-        .with_key_id("test_key")
-        .with_other_fields(HeaderExtensions {
-            custom: "custom".to_owned(),
-        })
+    Header::new(HeaderExtensions {
+        custom: "custom".to_owned(),
+    })
+    .with_token_type("JWT")
+    .with_key_id("test_key")
 }
 
 fn test_algorithm_with_custom_header<A: Algorithm>(

--- a/tests/rsa.rs
+++ b/tests/rsa.rs
@@ -84,7 +84,7 @@ fn ps256_checked_len_fails_on_undersized_key() {
     let small_private_key = RsaPrivateKey::new(&mut thread_rng(), 1_024).unwrap();
     let claims = create_claims();
     let token = Rsa::ps256()
-        .token(Header::empty(), &claims, &small_private_key)
+        .token(&Header::empty(), &claims, &small_private_key)
         .unwrap();
     let token = UntrustedToken::new(&token).unwrap();
 

--- a/tests/shared/mod.rs
+++ b/tests/shared/mod.rs
@@ -53,19 +53,19 @@ pub fn test_algorithm<A: Algorithm>(
     #[cfg(feature = "serde_cbor")]
     {
         let token_string = algorithm
-            .compact_token(Header::default(), &claims, signing_key)
+            .compact_token(Header::empty(), &claims, signing_key)
             .unwrap();
-        let token = UntrustedToken::try_from(token_string.as_str()).unwrap();
-        let token = algorithm.validate_integrity(&token, verifying_key).unwrap();
+        let token = UntrustedToken::new(&token_string).unwrap();
+        let token = algorithm.validator(verifying_key).validate(&token).unwrap();
         assert_eq!(*token.claims(), claims);
     }
 
     // Successful case.
     let token_string = algorithm
-        .token(Header::default(), &claims, signing_key)
+        .token(Header::empty(), &claims, signing_key)
         .unwrap();
-    let token = UntrustedToken::try_from(token_string.as_str()).unwrap();
-    let token = algorithm.validate_integrity(&token, verifying_key).unwrap();
+    let token = UntrustedToken::new(&token_string).unwrap();
+    let token = algorithm.validator(verifying_key).validate(&token).unwrap();
     assert_eq!(*token.claims(), claims);
 
     // Mutate signature bits.
@@ -88,9 +88,10 @@ pub fn test_algorithm<A: Algorithm>(
 
         let mut mangled_str = token_string.clone();
         mangled_str.replace_range(signature_start.., &mangled_signature);
-        let token = UntrustedToken::try_from(mangled_str.as_str()).unwrap();
+        let token = UntrustedToken::new(&mangled_str).unwrap();
         let err = algorithm
-            .validate_integrity::<Obj>(&token, verifying_key)
+            .validator::<Obj>(verifying_key)
+            .validate(&token)
             .unwrap_err();
         match err {
             ValidationError::InvalidSignature | ValidationError::MalformedSignature(_) => {}
@@ -105,9 +106,10 @@ pub fn test_algorithm<A: Algorithm>(
     assert_ne!(mangled_header, &token_string[..header_end]);
     let mut mangled_str = token_string.clone();
     mangled_str.replace_range(..header_end, &mangled_header);
-    let token = UntrustedToken::try_from(mangled_str.as_str()).unwrap();
+    let token = UntrustedToken::new(&mangled_str).unwrap();
     let err = algorithm
-        .validate_integrity::<Obj>(&token, verifying_key)
+        .validator::<Obj>(verifying_key)
+        .validate(&token)
         .unwrap_err();
     assert_matches!(err, ValidationError::InvalidSignature);
 
@@ -127,9 +129,10 @@ pub fn test_algorithm<A: Algorithm>(
     );
     let mut mangled_str = token_string.clone();
     mangled_str.replace_range((header_end + 1)..(signature_start - 1), &claims_string);
-    let token = UntrustedToken::try_from(mangled_str.as_str()).unwrap();
+    let token = UntrustedToken::new(&mangled_str).unwrap();
     let err = algorithm
-        .validate_integrity::<Obj>(&token, verifying_key)
+        .validator::<Obj>(verifying_key)
+        .validate(&token)
         .unwrap_err();
     assert_matches!(err, ValidationError::InvalidSignature);
 }

--- a/tests/shared/mod.rs
+++ b/tests/shared/mod.rs
@@ -53,7 +53,7 @@ pub fn test_algorithm<A: Algorithm>(
     #[cfg(feature = "serde_cbor")]
     {
         let token_string = algorithm
-            .compact_token(Header::empty(), &claims, signing_key)
+            .compact_token(&Header::empty(), &claims, signing_key)
             .unwrap();
         let token = UntrustedToken::new(&token_string).unwrap();
         let token = algorithm.validator(verifying_key).validate(&token).unwrap();
@@ -62,7 +62,7 @@ pub fn test_algorithm<A: Algorithm>(
 
     // Successful case.
     let token_string = algorithm
-        .token(Header::empty(), &claims, signing_key)
+        .token(&Header::empty(), &claims, signing_key)
         .unwrap();
     let token = UntrustedToken::new(&token_string).unwrap();
     let token = algorithm.validator(verifying_key).validate(&token).unwrap();


### PR DESCRIPTION
A straightforward implementation that (unfortunately?) forces to make breaking changes and deprecate some API (more info in the changelog).

closes #134