### PR TITLE
Supporting string thumbprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- Support padding in base64url encoding of certificate thumbprints in the JWT header.
+
 ### Changed
 
 - Update `secp256k1` and `rsa` dependencies.
@@ -15,6 +19,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
   a header with custom fields.
 - Take `Header<_>` by reference in `AlgorithmExt` methods creating tokens (previously,
   it was taken by value).
+- Support custom-encoded certificate thumbprints in JWT `Header` by replacing types
+  of the corresponding fields with a new `Thumbprint` enum. As an example,
+  this allows hex-encoded thumbprints (which are then additionally base64url-encoded)
+  produced by some software.
 
 ### Deprecated
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ pub mod prelude {
 pub use crate::{
     claims::{Claims, Empty, TimeOptions},
     error::{Claim, CreationError, ParseError, ValidationError},
-    token::{Header, SignedToken, Token, UntrustedToken},
+    token::{Header, SignedToken, Thumbprint, Token, UntrustedToken},
     traits::{Algorithm, AlgorithmExt, AlgorithmSignature, Renamed, Validator},
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,7 @@ mod alloc {
     pub use std::{
         borrow::{Cow, ToOwned},
         boxed::Box,
+        format,
         string::{String, ToString},
         vec::Vec,
     };

--- a/src/token.rs
+++ b/src/token.rs
@@ -10,7 +10,7 @@ use smallvec::{smallvec, SmallVec};
 use core::{cmp, fmt};
 
 use crate::{
-    alloc::{Cow, String, Vec},
+    alloc::{format, Cow, String, Vec},
     Algorithm, Claims, Empty, ParseError, ValidationError,
 };
 
@@ -591,7 +591,7 @@ mod tests {
     use super::*;
     use crate::{
         alg::{Hs256, Hs256Key},
-        alloc::ToOwned,
+        alloc::{ToOwned, ToString},
         AlgorithmExt, Empty,
     };
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,10 +1,13 @@
 //! `Token` and closely related types.
 
 use base64ct::{Base64UrlUnpadded, Encoding};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{
+    de::{DeserializeOwned, Error as DeError, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 use smallvec::{smallvec, SmallVec};
 
-use core::fmt;
+use core::{cmp, fmt};
 
 use crate::{
     alloc::{Cow, String, Vec},
@@ -13,6 +16,88 @@ use crate::{
 
 /// Maximum "reasonable" signature size in bytes.
 const SIGNATURE_SIZE: usize = 128;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Thumbprint<const N: usize> {
+    Bytes([u8; N]),
+    String(String),
+}
+
+impl<const N: usize> From<[u8; N]> for Thumbprint<N> {
+    fn from(value: [u8; N]) -> Self {
+        Self::Bytes(value)
+    }
+}
+
+impl<const N: usize> From<String> for Thumbprint<N> {
+    fn from(s: String) -> Self {
+        Self::String(s)
+    }
+}
+
+impl<const N: usize> Serialize for Thumbprint<N> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let input = match self {
+            Self::Bytes(bytes) => bytes.as_slice(),
+            Self::String(s) => s.as_bytes(),
+        };
+        serializer.serialize_str(&Base64UrlUnpadded::encode_string(input))
+    }
+}
+
+impl<'de, const N: usize> Deserialize<'de> for Thumbprint<N> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Base64Visitor<const L: usize>;
+
+        impl<const L: usize> Visitor<'_> for Base64Visitor<L> {
+            type Value = Thumbprint<L>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "base64url-encoded thumbprint")
+            }
+
+            fn visit_str<E: DeError>(self, mut value: &str) -> Result<Self::Value, E> {
+                // Allow for padding. RFC 7515 defines base64url encoding as one without padding:
+                //
+                // > Base64url Encoding: Base64 encoding using the URL- and filename-safe
+                // > character set defined in Section 5 of RFC 4648 [RFC4648], with all trailing '='
+                // > characters omitted [...]
+                //
+                // ...but it's easy to trim the padding, so we support it anyway.
+                //
+                // See: https://www.rfc-editor.org/rfc/rfc7515.html#section-2
+                for _ in 0..2 {
+                    if value.as_bytes().last() == Some(&b'=') {
+                        value = &value[..value.len() - 1];
+                    }
+                }
+
+                let decoded_len = value.len() * 3 / 4;
+                match decoded_len.cmp(&L) {
+                    cmp::Ordering::Less => Err(E::custom(format!(
+                        "thumbprint must contain at least {L} bytes"
+                    ))),
+                    cmp::Ordering::Equal => {
+                        let mut bytes = [0_u8; L];
+                        let len = Base64UrlUnpadded::decode(value, &mut bytes)
+                            .map_err(E::custom)?
+                            .len();
+                        debug_assert_eq!(len, L);
+                        Ok(bytes.into())
+                    }
+                    cmp::Ordering::Greater => {
+                        let decoded = Base64UrlUnpadded::decode_vec(value).map_err(E::custom)?;
+                        let decoded = String::from_utf8(decoded)
+                            .map_err(|err| E::custom(err.utf8_error()))?;
+                        Ok(decoded.into())
+                    }
+                }
+            }
+        }
+
+        deserializer.deserialize_str(Base64Visitor)
+    }
+}
 
 /// JWT header.
 ///
@@ -63,25 +148,15 @@ pub struct Header<T = Empty> {
     /// This field is renamed to [`x5t`] for serialization.
     ///
     /// [`x5t`]: https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.7
-    #[serde(
-        rename = "x5t",
-        with = "base64url",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub certificate_sha1_thumbprint: Option<[u8; 20]>,
+    #[serde(rename = "x5t", default, skip_serializing_if = "Option::is_none")]
+    pub certificate_sha1_thumbprint: Option<Thumbprint<20>>,
 
     /// SHA-256 thumbprint of the X.509 certificate for the signing key.
     /// This field is renamed to [`x5t#S256`] for serialization.
     ///
     /// [`x5t#S256`]: https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.8
-    #[serde(
-        rename = "x5t#S256",
-        with = "base64url",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub certificate_thumbprint: Option<[u8; 32]>,
+    #[serde(rename = "x5t#S256", default, skip_serializing_if = "Option::is_none")]
+    pub certificate_thumbprint: Option<Thumbprint<32>>,
 
     /// Application-specific [token type]. This field is renamed to `typ` for serialization.
     ///
@@ -157,14 +232,14 @@ impl<T> Header<T> {
     /// Sets the `certificate_sha1_thumbprint` field for this header.
     #[must_use]
     pub fn with_certificate_sha1_thumbprint(mut self, certificate_thumbprint: [u8; 20]) -> Self {
-        self.certificate_sha1_thumbprint = Some(certificate_thumbprint);
+        self.certificate_sha1_thumbprint = Some(Thumbprint::Bytes(certificate_thumbprint));
         self
     }
 
     /// Sets the `certificate_thumbprint` field for this header.
     #[must_use]
     pub fn with_certificate_thumbprint(mut self, certificate_thumbprint: [u8; 32]) -> Self {
-        self.certificate_thumbprint = Some(certificate_thumbprint);
+        self.certificate_thumbprint = Some(Thumbprint::Bytes(certificate_thumbprint));
         self
     }
 
@@ -450,72 +525,6 @@ impl<H> UntrustedToken<'_, H> {
     }
 }
 
-mod base64url {
-    use base64ct::{Base64UrlUnpadded, Encoding};
-    use serde::{
-        de::{Error as DeError, Visitor},
-        Deserializer, Serializer,
-    };
-
-    use core::{fmt, marker::PhantomData};
-
-    #[allow(clippy::option_if_let_else)] // false positive; `serializer` is moved into both clauses
-    pub fn serialize<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        T: AsRef<[u8]>,
-        S: Serializer,
-    {
-        if let Some(value) = value {
-            let bytes = value.as_ref();
-            serializer.serialize_str(&Base64UrlUnpadded::encode_string(bytes))
-        } else {
-            serializer.serialize_none()
-        }
-    }
-
-    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
-    where
-        T: Default + AsMut<[u8]>,
-        D: Deserializer<'de>,
-    {
-        struct Base64Visitor<V>(PhantomData<V>);
-
-        impl<V> Visitor<'_> for Base64Visitor<V>
-        where
-            V: Default + AsMut<[u8]>,
-        {
-            type Value = V;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(formatter, "base64url-encoded digest")
-            }
-
-            fn visit_str<E: DeError>(self, value: &str) -> Result<Self::Value, E> {
-                let mut bytes = V::default();
-                let expected_len = bytes.as_mut().len();
-
-                let decoded_len = value.len() * 3 / 4;
-                if decoded_len != expected_len {
-                    return Err(E::invalid_length(decoded_len, &self));
-                }
-
-                let len = Base64UrlUnpadded::decode(value, bytes.as_mut())
-                    .map_err(E::custom)?
-                    .len();
-                if len != expected_len {
-                    return Err(E::invalid_length(len, &self));
-                }
-
-                Ok(bytes)
-            }
-        }
-
-        deserializer
-            .deserialize_str(Base64Visitor(PhantomData))
-            .map(Some)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
@@ -592,7 +601,8 @@ mod tests {
     fn header_with_x5t_field() {
         let header = r#"{"alg":"HS256","x5t":"lDpwLQbzRZmu4fjajvn3KWAx1pk"}"#;
         let header: CompleteHeader<Header<Empty>> = serde_json::from_str(header).unwrap();
-        let thumbprint = header.inner.certificate_sha1_thumbprint.unwrap();
+        let thumbprint = header.inner.certificate_sha1_thumbprint.as_ref().unwrap();
+        let Thumbprint::Bytes(thumbprint) = thumbprint else { unreachable!() };
 
         assert_eq!(thumbprint[0], 0x94);
         assert_eq!(thumbprint[19], 0x99);
@@ -608,10 +618,77 @@ mod tests {
     }
 
     #[test]
+    fn header_with_padded_x5t_field() {
+        let header = r#"{"alg":"HS256","x5t":"lDpwLQbzRZmu4fjajvn3KWAx1pk=="}"#;
+        let header: CompleteHeader<Header<Empty>> = serde_json::from_str(header).unwrap();
+        let thumbprint = header.inner.certificate_sha1_thumbprint.as_ref().unwrap();
+        let Thumbprint::Bytes(thumbprint) = thumbprint else { unreachable!() };
+
+        assert_eq!(thumbprint[0], 0x94);
+        assert_eq!(thumbprint[19], 0x99);
+    }
+
+    #[test]
+    fn header_with_hex_x5t_field() {
+        let header =
+            r#"{"alg":"HS256","x5t":"NjVBRjY5MDlCMUIwNzU4RTA2QzZFMDQ4QzQ2MDAyQjVDNjk1RTM2Qg"}"#;
+        let header: CompleteHeader<Header<Empty>> = serde_json::from_str(header).unwrap();
+        let thumbprint = header.inner.certificate_sha1_thumbprint.as_ref().unwrap();
+        let Thumbprint::String(thumbprint) = thumbprint else { unreachable!() };
+
+        assert_eq!(thumbprint, "65AF6909B1B0758E06C6E048C46002B5C695E36B");
+
+        let json = serde_json::to_value(header).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "alg": "HS256",
+                "x5t": "NjVBRjY5MDlCMUIwNzU4RTA2QzZFMDQ4QzQ2MDAyQjVDNjk1RTM2Qg",
+            })
+        );
+    }
+
+    #[test]
+    fn header_with_padded_hex_x5t_field() {
+        let header =
+            r#"{"alg":"HS256","x5t":"NjVBRjY5MDlCMUIwNzU4RTA2QzZFMDQ4QzQ2MDAyQjVDNjk1RTM2Qg=="}"#;
+        let header: CompleteHeader<Header<Empty>> = serde_json::from_str(header).unwrap();
+        let thumbprint = header.inner.certificate_sha1_thumbprint.as_ref().unwrap();
+        let Thumbprint::String(thumbprint) = thumbprint else { unreachable!() };
+
+        assert_eq!(thumbprint, "65AF6909B1B0758E06C6E048C46002B5C695E36B");
+    }
+
+    #[test]
+    fn header_with_overly_short_x5t_field() {
+        let header = r#"{"alg":"HS256","x5t":"aGk="}"#;
+        let err = serde_json::from_str::<CompleteHeader<Header<Empty>>>(header).unwrap_err();
+        let err = err.to_string();
+        assert!(
+            err.contains("thumbprint must contain at least 20 bytes"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn header_with_non_base64_x5t_field() {
+        let headers = [
+            r#"{"alg":"HS256","x5t":"lDpwLQbzRZmu4fjajvn3KWAx1p?"}"#,
+            r#"{"alg":"HS256","x5t":"NjVBRjY5MDlCMUIwNzU4RTA2QzZFMDQ4QzQ2MDAyQjVDNjk!RTM2Qg"}"#,
+        ];
+        for header in headers {
+            let err = serde_json::from_str::<CompleteHeader<Header<Empty>>>(header).unwrap_err();
+            let err = err.to_string();
+            assert!(err.contains("Base64"), "{err}");
+        }
+    }
+
+    #[test]
     fn header_with_x5t_sha256_field() {
         let header = r#"{"alg":"HS256","x5t#S256":"MV9b23bQeMQ7isAGTkoBZGErH853yGk0W_yUx1iU7dM"}"#;
         let header: CompleteHeader<Header<Empty>> = serde_json::from_str(header).unwrap();
-        let thumbprint = header.inner.certificate_thumbprint.unwrap();
+        let thumbprint = header.inner.certificate_thumbprint.as_ref().unwrap();
+        let Thumbprint::Bytes(thumbprint) = thumbprint else { unreachable!() };
 
         assert_eq!(thumbprint[0], 0x31);
         assert_eq!(thumbprint[31], 0xd3);


### PR DESCRIPTION
This PR generalizes SHA-1 / SHA-256 certificate thumbprints in JWT `Header` so that custom-encoded thumbprints (e.g., hex-encoded ones) are supported.

closes #141