### PR TITLE
Bump crate version to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## 0.8.0 - 2023-10-12
+
+*(All changes are relative compared to [the 0.8.0-beta.1 release](#080-beta1---2023-06-09))*
+
 ### Added
 
 - Support floating-point timestamps in claims.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "jwt-compact"
-version = "0.8.0-beta.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jwt-compact"
-version = "0.8.0-beta.1"
+version = "0.8.0"
 authors = [
   "Alex Ostrovski <ostrovski.alex@gmail.com>",
   "Akhil Velagapudi <akhilvelagapudi@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dependencies]
-jwt-compact = "0.8.0-beta.1"
+jwt-compact = "0.8.0"
 ```
 
 ## Basic token lifecycle

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // Documentation settings.
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/jwt-compact/0.8.0-beta.1")]
+#![doc(html_root_url = "https://docs.rs/jwt-compact/0.8.0")]
 // Linter settings.
 #![warn(missing_debug_implementations, missing_docs, bare_trait_objects)]
 #![warn(clippy::all, clippy::pedantic)]


### PR DESCRIPTION
## What?

Prepares the crate for the 0.8.0 release.

## Why?

The new release includes a couple of fixes and publishes changes that were only available in the beta release.
