### PR TITLE
Prepare 0.9.0-beta.1 release

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo
 
       - name: Format
-        run: cargo fmt --all -- --check
+        run: cargo fmt --all -- --check --config imports_granularity=Crate --config group_imports=StdExternalCrate
       - name: Clippy
         run: cargo clippy -p jwt-compact --features p256,es256k,rsa,rsa/pem --all-targets -- -D warnings
       - name: Clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## 0.9.0-beta.1 - 2024-09-29
+
 ### Changed
 
 - Bump minimum supported Rust version to 1.70.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 ### Changed
 
 - Bump minimum supported Rust version to 1.70.
+- Update `secp256k1` dependency.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ and describe the motivation behind it. If applicable, like to the related issue(
 Optimally, you should check locally that the CI checks pass before submitting the PR. Checks included in the CI
 include:
 
-- Formatting using `cargo fmt --all`
+- Formatting using `cargo fmt --all -- --config imports_granularity=Crate --config group_imports=StdExternalCrate`
 - Linting using `cargo clippy`
 - Linting the dependency graph using [`cargo deny`](https://crates.io/crates/cargo-deny)
 - Running the test suite using `cargo test`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "jwt-compact"
-version = "0.8.0"
+version = "0.9.0-beta.1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jwt-compact"
-version = "0.8.0"
+version = "0.9.0-beta.1"
 authors = [
   "Alex Ostrovski <ostrovski.alex@gmail.com>",
   "Akhil Velagapudi <akhilvelagapudi@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dependencies]
-jwt-compact = "0.8.0"
+jwt-compact = "0.9.0-beta.1"
 ```
 
 ## Basic token lifecycle

--- a/benches/encoding.rs
+++ b/benches/encoding.rs
@@ -2,13 +2,12 @@
 
 use chrono::{Duration, Utc};
 use criterion::{criterion_group, criterion_main, Criterion};
-use serde::{Deserialize, Serialize};
-use uuid::Uuid;
-
 use jwt_compact::{
     alg::{Hs256, Hs256Key},
     AlgorithmExt, Claims, Header, TimeOptions, UntrustedToken,
 };
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 // Fairly small list of claims.
 #[derive(Serialize, Deserialize)]

--- a/e2e-tests/no-std/src/main.rs
+++ b/e2e-tests/no-std/src/main.rs
@@ -5,16 +5,13 @@
 
 extern crate alloc;
 
+use alloc::{borrow::ToOwned, string::String};
+
 use anyhow::anyhow;
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln, syscall};
 use embedded_alloc::LlffHeap as Heap;
-use panic_halt as _;
-use serde::{Deserialize, Serialize};
-
-use alloc::{borrow::ToOwned, string::String};
-
 #[cfg(feature = "ed25519")]
 use jwt_compact::alg::Ed25519;
 #[cfg(feature = "rsa")]
@@ -24,6 +21,8 @@ use jwt_compact::{
     prelude::*,
     Algorithm,
 };
+use panic_halt as _;
+use serde::{Deserialize, Serialize};
 
 #[global_allocator]
 static ALLOCATOR: Heap = Heap::empty();

--- a/e2e-tests/wasm/src/lib.rs
+++ b/e2e-tests/wasm/src/lib.rs
@@ -5,19 +5,18 @@
 
 extern crate alloc;
 
-use chrono::Duration;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Error as JsonError;
-use wasm_bindgen::prelude::*;
-
 use alloc::string::{String, ToString};
 use core::fmt;
 
+use chrono::Duration;
 use jwt_compact::{
     alg::{Ed25519, Es256, Es256k, Hs256, Hs384, Hs512, Rsa},
     jwk::{JsonWebKey, JwkError},
     Algorithm, AlgorithmExt, Claims, Header, TimeOptions, Token, UntrustedToken,
 };
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Error as JsonError;
+use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {

--- a/src/alg.rs
+++ b/src/alg.rs
@@ -3,6 +3,28 @@
 
 use core::fmt;
 
+#[cfg(feature = "ed25519-compact")]
+pub use self::eddsa_compact::*;
+#[cfg(feature = "ed25519-dalek")]
+pub use self::eddsa_dalek::Ed25519;
+#[cfg(feature = "exonum-crypto")]
+pub use self::eddsa_sodium::Ed25519;
+#[cfg(feature = "es256k")]
+pub use self::es256k::Es256k;
+#[cfg(feature = "k256")]
+pub use self::k256::Es256k;
+#[cfg(feature = "p256")]
+pub use self::p256::Es256;
+#[cfg(feature = "rsa")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
+pub use self::rsa::{
+    ModulusBits, ModulusBitsError, Rsa, RsaError, RsaParseError, RsaPrivateKey, RsaPublicKey,
+    RsaSignature,
+};
+pub use self::{
+    generic::{SecretBytes, SigningKey, VerifyingKey},
+    hmacs::*,
+};
 use crate::{alloc::Cow, Algorithm};
 
 mod generic;
@@ -25,27 +47,6 @@ mod p256;
 // RSA implementation.
 #[cfg(feature = "rsa")]
 mod rsa;
-
-#[cfg(feature = "ed25519-compact")]
-pub use self::eddsa_compact::*;
-#[cfg(feature = "ed25519-dalek")]
-pub use self::eddsa_dalek::Ed25519;
-#[cfg(feature = "exonum-crypto")]
-pub use self::eddsa_sodium::Ed25519;
-#[cfg(feature = "es256k")]
-pub use self::es256k::Es256k;
-pub use self::generic::{SecretBytes, SigningKey, VerifyingKey};
-pub use self::hmacs::*;
-#[cfg(feature = "k256")]
-pub use self::k256::Es256k;
-#[cfg(feature = "p256")]
-pub use self::p256::Es256;
-#[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
-pub use self::rsa::{
-    ModulusBits, ModulusBitsError, Rsa, RsaError, RsaParseError, RsaPrivateKey, RsaPublicKey,
-    RsaSignature,
-};
 
 /// Wrapper around keys allowing to enforce key strength requirements.
 ///

--- a/src/alg/eddsa_compact.rs
+++ b/src/alg/eddsa_compact.rs
@@ -1,9 +1,9 @@
 //! `EdDSA` algorithm implementation using the `ed25519-compact` crate.
 
+use core::num::NonZeroUsize;
+
 use ed25519_compact::{KeyPair, Noise, PublicKey, SecretKey, Seed, Signature};
 use rand_core::{CryptoRng, RngCore};
-
-use core::num::NonZeroUsize;
 
 use crate::{
     alg::{SecretBytes, SigningKey, VerifyingKey},

--- a/src/alg/eddsa_dalek.rs
+++ b/src/alg/eddsa_dalek.rs
@@ -1,11 +1,11 @@
 //! `EdDSA` algorithm implementation using the `ed25519-dalek` crate.
 
+use core::num::NonZeroUsize;
+
 use ed25519_dalek::{
     SecretKey, Signature, Signer, Verifier, KEYPAIR_LENGTH, PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH,
     SIGNATURE_LENGTH,
 };
-
-use core::num::NonZeroUsize;
 
 use crate::{
     alg::{SecretBytes, SigningKey, VerifyingKey},

--- a/src/alg/eddsa_sodium.rs
+++ b/src/alg/eddsa_sodium.rs
@@ -1,12 +1,12 @@
 //! `EdDSA` algorithm implementation using the `exonum-crypto` crate.
 
+use core::num::NonZeroUsize;
+
 use anyhow::format_err;
 use exonum_crypto::{
     gen_keypair_from_seed, sign, verify, PublicKey, SecretKey, Seed, Signature, PUBLIC_KEY_LENGTH,
     SEED_LENGTH, SIGNATURE_LENGTH,
 };
-
-use core::num::NonZeroUsize;
 
 use crate::{
     alg::{SecretBytes, SigningKey, VerifyingKey},

--- a/src/alg/es256k.rs
+++ b/src/alg/es256k.rs
@@ -1,5 +1,7 @@
 //! `ES256K` algorithm implementation using the `secp256k1` crate.
 
+use core::{marker::PhantomData, num::NonZeroUsize};
+
 use lazy_static::lazy_static;
 use secp256k1::{
     constants::{
@@ -14,8 +16,6 @@ use sha2::{
     },
     Digest, Sha256,
 };
-
-use core::{marker::PhantomData, num::NonZeroUsize};
 
 use crate::{
     alg::{SecretBytes, SigningKey, VerifyingKey},

--- a/src/alg/generic.rs
+++ b/src/alg/generic.rs
@@ -1,9 +1,9 @@
 //! Generic traits providing uniform interfaces for a certain cryptosystem
 //! across different backends.
 
-use zeroize::Zeroize;
-
 use core::{fmt, ops};
+
+use zeroize::Zeroize;
 
 use crate::{
     alloc::{Cow, Vec},

--- a/src/alg/hmacs.rs
+++ b/src/alg/hmacs.rs
@@ -1,7 +1,14 @@
 //! JWT algorithms based on HMACs.
 
-use hmac::digest::generic_array::{typenum::Unsigned, GenericArray};
-use hmac::{digest::CtOutput, Hmac, Mac as _};
+use core::{fmt, num::NonZeroUsize};
+
+use hmac::{
+    digest::{
+        generic_array::{typenum::Unsigned, GenericArray},
+        CtOutput,
+    },
+    Hmac, Mac as _,
+};
 use rand_core::{CryptoRng, RngCore};
 use sha2::{
     digest::{core_api::BlockSizeUser, OutputSizeUser},
@@ -9,8 +16,6 @@ use sha2::{
 };
 use smallvec::{smallvec, SmallVec};
 use zeroize::Zeroize;
-
-use core::{fmt, num::NonZeroUsize};
 
 use crate::{
     alg::{SecretBytes, SigningKey, StrongKey, VerifyingKey, WeakKeyError},

--- a/src/alg/k256.rs
+++ b/src/alg/k256.rs
@@ -1,5 +1,7 @@
 //! `ES256K` algorithm implementation using the `k256` crate.
 
+use core::{marker::PhantomData, num::NonZeroUsize, ops::Add};
+
 use k256::{
     ecdsa::{
         signature::{DigestSigner, DigestVerifier},
@@ -9,8 +11,6 @@ use k256::{
     Secp256k1,
 };
 use sha2::{digest::typenum::Unsigned, Digest, Sha256};
-
-use core::{marker::PhantomData, num::NonZeroUsize, ops::Add};
 
 use crate::{
     alg::{self, SecretBytes},

--- a/src/alg/p256.rs
+++ b/src/alg/p256.rs
@@ -1,12 +1,12 @@
 //! `ES256` algorithm implementation using the `p256` crate.
 
+use core::num::NonZeroUsize;
+
 use p256::ecdsa::{
     signature::{DigestSigner, DigestVerifier},
     Signature, SigningKey, VerifyingKey,
 };
 use sha2::{Digest, Sha256};
-
-use core::num::NonZeroUsize;
 
 use crate::{
     alg::{self, SecretBytes},

--- a/src/alg/rsa.rs
+++ b/src/alg/rsa.rs
@@ -1,15 +1,14 @@
 //! RSA-based JWT algorithms: `RS*` and `PS*`.
 
-pub use rsa::{errors::Error as RsaError, RsaPrivateKey, RsaPublicKey};
+use core::{fmt, str::FromStr};
 
 use rand_core::{CryptoRng, RngCore};
+pub use rsa::{errors::Error as RsaError, RsaPrivateKey, RsaPublicKey};
 use rsa::{
     traits::{PrivateKeyParts, PublicKeyParts},
     BigUint, Pkcs1v15Sign, Pss,
 };
 use sha2::{Digest, Sha256, Sha384, Sha512};
-
-use core::{fmt, str::FromStr};
 
 use crate::{
     alg::{SecretBytes, StrongKey, WeakKeyError},

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -212,13 +212,13 @@ impl<T> Claims<T> {
 }
 
 mod serde_timestamp {
+    use core::fmt;
+
     use chrono::{offset::TimeZone, DateTime, Utc};
     use serde::{
         de::{Error as DeError, Visitor},
         Deserializer, Serializer,
     };
-
-    use core::fmt;
 
     struct TimestampVisitor;
 
@@ -277,9 +277,10 @@ mod serde_timestamp {
 
 #[cfg(all(test, feature = "clock"))]
 mod tests {
-    use super::*;
     use assert_matches::assert_matches;
     use chrono::TimeZone;
+
+    use super::*;
 
     #[test]
     fn empty_claims_can_be_serialized() {

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -33,10 +33,10 @@
 //! # }
 //! ```
 
+use core::fmt;
+
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::digest::{Digest, Output};
-
-use core::fmt;
 
 use crate::{
     alg::SecretBytes,
@@ -476,13 +476,13 @@ mod helpers {
 }
 
 mod base64url {
+    use core::fmt;
+
     use base64ct::{Base64UrlUnpadded, Encoding};
     use serde::{
         de::{Error as DeError, Unexpected, Visitor},
         Deserializer, Serializer,
     };
-
-    use core::fmt;
 
     use crate::alloc::{Cow, Vec};
 
@@ -553,10 +553,10 @@ mod base64url {
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
+
     use super::*;
     use crate::alg::Hs256Key;
-
-    use assert_matches::assert_matches;
 
     fn create_jwk() -> JsonWebKey<'static> {
         JsonWebKey::KeyPair {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,6 +239,13 @@
     clippy::module_name_repetitions
 )]
 
+pub use crate::{
+    claims::{Claims, Empty, TimeOptions},
+    error::{Claim, CreationError, ParseError, ValidationError},
+    token::{Header, SignedToken, Thumbprint, Token, UntrustedToken},
+    traits::{Algorithm, AlgorithmExt, AlgorithmSignature, Renamed, Validator},
+};
+
 pub mod alg;
 mod claims;
 mod error;
@@ -264,13 +271,6 @@ pub mod prelude {
     #[doc(no_inline)]
     pub use crate::{AlgorithmExt as _, Claims, Header, TimeOptions, Token, UntrustedToken};
 }
-
-pub use crate::{
-    claims::{Claims, Empty, TimeOptions},
-    error::{Claim, CreationError, ParseError, ValidationError},
-    token::{Header, SignedToken, Thumbprint, Token, UntrustedToken},
-    traits::{Algorithm, AlgorithmExt, AlgorithmSignature, Renamed, Validator},
-};
 
 #[cfg(doctest)]
 doc_comment::doctest!("../README.md");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // Documentation settings.
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/jwt-compact/0.8.0")]
+#![doc(html_root_url = "https://docs.rs/jwt-compact/0.9.0-beta.1")]
 // Linter settings.
 #![warn(missing_debug_implementations, missing_docs, bare_trait_objects)]
 #![warn(clippy::all, clippy::pedantic)]

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,13 +1,13 @@
 //! `Token` and closely related types.
 
+use core::{cmp, fmt};
+
 use base64ct::{Base64UrlUnpadded, Encoding};
 use serde::{
     de::{DeserializeOwned, Error as DeError, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use smallvec::{smallvec, SmallVec};
-
-use core::{cmp, fmt};
 
 #[cfg(feature = "ciborium")]
 use crate::error::CborDeError;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,9 +1,9 @@
 //! Key traits defined by the crate.
 
+use core::{marker::PhantomData, num::NonZeroUsize};
+
 use base64ct::{Base64UrlUnpadded, Encoding};
 use serde::{de::DeserializeOwned, Serialize};
-
-use core::{marker::PhantomData, num::NonZeroUsize};
 
 #[cfg(feature = "ciborium")]
 use crate::error::CborSerError;

--- a/tests/algorithms.rs
+++ b/tests/algorithms.rs
@@ -3,16 +3,16 @@
 use assert_matches::assert_matches;
 use base64ct::{Base64UrlUnpadded, Encoding};
 use chrono::{TimeZone, Utc};
+use jwt_compact::{
+    alg::*, prelude::*, Algorithm, AlgorithmExt, ParseError, Thumbprint, ValidationError,
+};
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-mod shared;
-
 use crate::shared::{create_claims, test_algorithm, Obj, SampleClaims};
-use jwt_compact::{
-    alg::*, prelude::*, Algorithm, AlgorithmExt, ParseError, Thumbprint, ValidationError,
-};
+
+mod shared;
 
 #[test]
 fn hs256_reference() {

--- a/tests/jwk.rs
+++ b/tests/jwk.rs
@@ -4,12 +4,11 @@
 
 use assert_matches::assert_matches;
 use base64ct::{Base64UrlUnpadded, Encoding};
-use sha2::{digest::Digest, Sha256, Sha384, Sha512};
-
 use jwt_compact::{
     alg::Hs256Key,
     jwk::{JsonWebKey, JwkError, KeyType},
 };
+use sha2::{digest::Digest, Sha256, Sha384, Sha512};
 
 fn key_thumbprint<'a, D, K>(key: &'a K) -> String
 where
@@ -90,11 +89,11 @@ fn hs256_incorrect_key_type() {
 
 #[cfg(feature = "rsa")]
 mod rsa_jwk {
-    use super::*;
-
     use num_bigint::{ModInverse, RandPrime};
     use rand::{thread_rng, Rng};
     use rsa::{errors::Error as RsaError, BigUint, RsaPrivateKey, RsaPublicKey};
+
+    use super::*;
 
     // This code is taken from the `rsa` crate, where it was made private in v0.9
     // because of high possibility of misuse.
@@ -295,8 +294,7 @@ mod rsa_jwk {
 
 #[cfg(any(feature = "es256k", feature = "k256"))]
 mod es256k {
-    use super::*;
-
+    use const_decoder::Decoder::Hex;
     #[cfg(feature = "k256")]
     use jwt_compact::alg::VerifyingKey;
     use jwt_compact::{
@@ -304,7 +302,7 @@ mod es256k {
         Algorithm,
     };
 
-    use const_decoder::Decoder::Hex;
+    use super::*;
 
     type SecretKey = <Es256k as Algorithm>::SigningKey;
     type PublicKey = <Es256k as Algorithm>::VerifyingKey;
@@ -489,14 +487,13 @@ mod es256k {
 
 #[cfg(feature = "p256")]
 mod es256 {
-    use super::*;
-
+    use const_decoder::Decoder::Hex;
     use jwt_compact::{
         alg::{Es256, SigningKey, VerifyingKey},
         Algorithm,
     };
 
-    use const_decoder::Decoder::Hex;
+    use super::*;
 
     type SecretKey = <Es256 as Algorithm>::SigningKey;
     type PublicKey = <Es256 as Algorithm>::VerifyingKey;
@@ -685,13 +682,13 @@ mod es256 {
     feature = "ed25519-compact"
 ))]
 mod ed25519 {
-    use super::*;
+    use const_decoder::Decoder::Hex;
     use jwt_compact::{
         alg::{Ed25519, SigningKey, VerifyingKey},
         Algorithm,
     };
 
-    use const_decoder::Decoder::Hex;
+    use super::*;
 
     type SecretKey = <Ed25519 as Algorithm>::SigningKey;
     type PublicKey = <Ed25519 as Algorithm>::VerifyingKey;

--- a/tests/rsa.rs
+++ b/tests/rsa.rs
@@ -1,13 +1,13 @@
 //! Tests for RSA algorithms.
 
 use assert_matches::assert_matches;
+use jwt_compact::{alg::*, prelude::*, Algorithm, ValidationError};
 use rand::thread_rng;
 use rsa::{pkcs1::DecodeRsaPrivateKey, pkcs8::DecodePublicKey};
 
-mod shared;
-
 use crate::shared::{create_claims, test_algorithm, CompactClaims, SampleClaims};
-use jwt_compact::{alg::*, prelude::*, Algorithm, ValidationError};
+
+mod shared;
 
 const RSA_PRIVATE_KEY: &str = "\
 -----BEGIN RSA PRIVATE KEY-----

--- a/tests/shared/mod.rs
+++ b/tests/shared/mod.rs
@@ -4,10 +4,9 @@ use assert_matches::assert_matches;
 use base64ct::{Base64UrlUnpadded, Encoding};
 use chrono::{Duration, TimeZone, Utc};
 use hex_buffer_serde::{Hex as _, HexForm};
+use jwt_compact::{prelude::*, Algorithm, ValidationError};
 use rand::{seq::index::sample as sample_indexes, thread_rng};
 use serde::{Deserialize, Serialize};
-
-use jwt_compact::{prelude::*, Algorithm, ValidationError};
 
 pub type Obj = serde_json::Map<String, serde_json::Value>;
 


### PR DESCRIPTION
## What?

Prepares the codebase for the next beta release.

## Why?

A release would incorporate some improvements, although lack of a stable `rsa` version with a fix against Marvin is suboptimal.