### PR TITLE
Add ability to BYO rng for embedded purposes

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -65,7 +65,7 @@ jobs:
         run: cargo deny --workspace check
 
       - name: Run tests
-        run: cargo test -p jwt-compact --features exonum-crypto,p256,es256k,rsa,rsa/pem
+        run: cargo test -p jwt-compact --features exonum-crypto,p256,es256k,rsa,rsa/pem,rsa-byo
       - name: Test dalek crypto
         run: cargo test -p jwt-compact --no-default-features --features std,ed25519-dalek --lib --tests
       - name: Test ed25519-compact

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ clock = ["chrono/clock"]
 es256k = ["secp256k1", "lazy_static"]
 # RSA algorithm and its dependencies (currently, `getrandom`-based RNG).
 rsa = ["dep:rsa", "rand_core/getrandom", "sha2/oid"]
+rsa-byo = ["dep:rsa", "sha2/oid"]
 
 [[bench]]
 name = "encoding"

--- a/src/alg.rs
+++ b/src/alg.rs
@@ -15,8 +15,11 @@ pub use self::es256k::Es256k;
 pub use self::k256::Es256k;
 #[cfg(feature = "p256")]
 pub use self::p256::Es256;
-#[cfg(feature = "rsa")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rsa")))]
+#[cfg(feature = "rsa-byo")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rsa-byo")))]
+pub use self::rsa::RsaByo;
+#[cfg(any(feature = "rsa", feature = "rsa-byo"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "rsa", feature = "rsa-byo"))))]
 pub use self::rsa::{
     ModulusBits, ModulusBitsError, Rsa, RsaError, RsaParseError, RsaPrivateKey, RsaPublicKey,
     RsaSignature,
@@ -45,7 +48,7 @@ mod eddsa_sodium;
 #[cfg(feature = "p256")]
 mod p256;
 // RSA implementation.
-#[cfg(feature = "rsa")]
+#[cfg(any(feature = "rsa", feature = "rsa-byo"))]
 mod rsa;
 
 /// Wrapper around keys allowing to enforce key strength requirements.


### PR DESCRIPTION
## What?

This adds the ability to pass a `CryptoRngCore` into `RSA` to enable its use in embedded cases.

## Why?

`jwt-compact` is practically the only `jwt` library which doesn't require `std`. Since `RSA` is the more common algorithm (Google requires it), being able to use the library in embedded software would be quite handy.